### PR TITLE
Proper step referencing inside arrays

### DIFF
--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/ExpressionGenerator.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/ExpressionGenerator.xtend
@@ -10,12 +10,10 @@ import java.util.ArrayList
 class ExpressionGenerator extends ExpressionsCommaGenerator {
 	EList<StepReference> stepRef
 	String stepName
-    String prefix
 
-	new(EList<StepReference> stepRef, String stepName, String prefix) {
+	new(EList<StepReference> stepRef, String stepName) {
 		this.stepRef = stepRef
 		this.stepName = stepName
-		this.prefix = prefix
 	}
 
 	override CharSequence getFunctionText(ExpressionFunctionCall e) {
@@ -64,12 +62,24 @@ class ExpressionGenerator extends ExpressionsCommaGenerator {
 		}
 	}
 
-	 override dispatch CharSequence exprToComMASyntax(ExpressionVector e) {
+    override dispatch CharSequence exprToComMASyntax(ExpressionVector e) {
         var typ = typeToComMASyntax(e.typeAnnotation.type)
         var lst = new ArrayList<String>()
         for (el : e.elements) {
-            lst.add(this.prefix + exprToComMASyntax(el).toString)
+            var ename = exprToComMASyntax(el).toString
+            var prefix = ""
+            if (this.stepRef !== null) {
+                for (sf : this.stepRef) {
+                    for (rd : sf.refData) {
+                        if (ename.contains(rd.name)) {
+                            prefix = "step_" + sf.refStep.name + ".output."
+                        }
+                    }
+                }
+            }
+            lst.add(prefix + exprToComMASyntax(el).toString)
         }
         return "<" + typ + ">[" + lst.join(", ") + "]"
     }
+
 }

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/FromAbstractToConcrete.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/FromAbstractToConcrete.xtend
@@ -77,7 +77,7 @@ class FromAbstractToConcrete
 
 	def printRecord(String stepName, String prefix, EList<StepReference> stepRef, RecordFieldAssignmentAction rec) {
 		var field = printField(rec.fieldAccess)
-		var value = (new ExpressionGenerator(stepRef,stepName,prefix)).exprToComMASyntax(rec.exp)
+		var value = (new ExpressionGenerator(stepRef,stepName)).exprToComMASyntax(rec.exp)
 		var p = (rec.exp instanceof ExpressionVector || rec.exp instanceof ExpressionFunctionCall) ? "" : prefix
 		return field + " := " + p + value
 	}

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/TestspecificationGenerator.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/TestspecificationGenerator.xtend
@@ -42,7 +42,7 @@ class TestspecificationGenerator extends AbstractGenerator
 	var Resource _resource
 	
 	/* TODO this should come from project task? Investigate and Implement it. */
-	var record_path_for_lot_def = "TwinscanControllerInput.concrete_expose_job.lot_def" 
+	var record_path_for_lot_def = "TwinscanControllerInput.concrete_expose_job.lot_definition" 
 	var record_lot_def_file_name = "lot_definition"
 	var record_lot_def_file_path_prefix = "./vfab2_scenario/FAST/generated_FAST/dataset/"
 	


### PR DESCRIPTION
When we update arrays we should reference the precise step output for each element in the array (there may not be a single step output for all of them)