### PR TITLE
adding identifier to assertions and enabling reference to fields

### DIFF
--- a/bundles/nl.esi.comma.assertthat/src/nl/esi/comma/assertthat/AssertThat.xtext
+++ b/bundles/nl.esi.comma.assertthat/src/nl/esi/comma/assertthat/AssertThat.xtext
@@ -20,23 +20,21 @@ AssertThatBlock:
 ;
 
 GenericScriptBlock:
-    assignment = Variable ':=' 'script-call' params = ScriptParametersBlock
+    assignment = Variable ':=' 'script-call' params = ScriptParametersCustom
 ;
 
-ScriptParametersBlock:
-    (
-        '{'
+ScriptParametersCustom:
+    '{'
+        'script-path' ':'   scriptPath = STRING
+        ('positional-args' ':'  paramsPositional = ExpressionArray  ) ?
+        ('named-args' ':'       paramsNamed      = ExpressionMap ) ?
+    '}' 
+;
+ScriptParametersFromVariable:
+    '{'
         'using-variable' ':'   paramsVariable  = Expression
         ('with-positional-args' ':' positionalField = STRING ) ?
-        '}'
-    )
-    | (
-        '{'
-            'path' ':'   scriptName=STRING
-            ('positional-args' ':'  paramsPositional = ExpressionArray  ) ?
-            ('named-args' ':'       paramsNamed      = ExpressionMap ) ?
-        '}' 
-    )
+    '}'
 ;
 
 enum MARGIN_TYPE:
@@ -70,7 +68,7 @@ AssertMatch:
 ;
 
 AssertSize:
-    'has-size' itLen=INT
+    'has-size' outLen=INT
 ;
 
 // Assertion of XPath outputs
@@ -100,11 +98,7 @@ XPathItem: {XPathItem}
 ;
 
 AssertXPathValidations: {AssertXPathValidations}
-    ( xpathItem = XPathItem ) validation = AssertionXPathValidationTypes
-;
-
-AssertionXPathValidationTypes:
-    AssertionValueValidationTypes
+    ( xpathItem = XPathItem ) validation = (AssertEq | AssertClose | AssertMatch | AssertSize)
 ;
 
 // Assertion of XMLFile outputs

--- a/bundles/nl.esi.comma.assertthat/src/nl/esi/comma/assertthat/AssertThat.xtext
+++ b/bundles/nl.esi.comma.assertthat/src/nl/esi/comma/assertthat/AssertThat.xtext
@@ -11,7 +11,7 @@ DataCheckItems:
 
 
 AssertThatBlock:
-    'assert-that' output=ExpressionBracket
+    name = ID ':' 'assert-that' output=ExpressionBracket
         (
               val=AssertThatValue 
             | xpath=AssertThatXPath 
@@ -20,7 +20,7 @@ AssertThatBlock:
 ;
 
 GenericScriptBlock:
-    assignment =[expr::Variable | ID] ':=' 'script-call' params = ScriptParametersBlock
+    assignment = Variable ':=' 'script-call' params = ScriptParametersBlock
 ;
 
 ScriptParametersBlock:
@@ -62,11 +62,11 @@ AssertEq:
 ;
 
 AssertClose:
-    'close-to' outClo=NumericOrArray ('within-margin' outMrg=MargingItem)?
+    'close-to' outClo=Expression ('within-margin' outMrg=MargingItem)?
 ;
 
 AssertMatch:
-    'match-regex' outRegex=StringOrArray
+    'match-regex' outRegex=Expression
 ;
 
 AssertSize:
@@ -164,13 +164,12 @@ JsonNumeric:
 ;
 
 JsonValue:
-    {JsonValue} STRING | {JsonValue} Expression::BOOL_LITERAL | JsonNumeric | JsonObject | JsonArray 
+    {JsonValue} ( fieldAccess=FieldAccessExp | STRING | Expression::BOOL_LITERAL ) | JsonNumeric | JsonObject | JsonArray
 ;
 
 StringOrArray:
     item = STRING | '[' (values+=STRING) (',' values+=STRING)* ']'
 ;
-
 NumericOrArray:
     item = JsonNumeric | '[' (values+=JsonNumeric) (',' values+=JsonNumeric)* ']'
 ;


### PR DESCRIPTION
For accessing assert-that and script-call elements from T-Spec, we need identifiers assigned to them.

I included and ID in the assert-that and script-call DSL fragments for that purpose