### PR TITLE
Temporarily removing the temp folder cleanup (for dev/debug purposes)

### DIFF
--- a/bundles/nl.esi.comma.project.standard.cli/dist/simulator/CPNServer.py
+++ b/bundles/nl.esi.comma.project.standard.cli/dist/simulator/CPNServer.py
@@ -173,4 +173,4 @@ if __name__ == "__main__":
     app.run(host="0.0.0.0", debug=False)
 
 
-TEMP_FILE.cleanup()
+# TEMP_FILE.cleanup()


### PR DESCRIPTION
as requested by @dbera I disabled the tempfolder cleanup done upon closure of the CPNServer.