### PR TITLE
closes #86 sut configurations

### DIFF
--- a/bundles/nl.asml.matala.bpmn4s/src/nl/asml/matala/bpmn4s/Main.java
+++ b/bundles/nl.asml.matala.bpmn4s/src/nl/asml/matala/bpmn4s/Main.java
@@ -277,6 +277,8 @@ public class Main {
 		node.setDataType(dtname);
 		String init = elem.getAttributeValueNs("http://bpmn4s", "init");
 		node.setInit(init);
+		String sutConf = elem.getAttributeValueNs("http://bpmn4s", "sutConfigurations");
+		node.setIsSutConfigurations("true".equals(sutConf));
 		model.addElement(id, node);
 	}
 	

--- a/bundles/nl.asml.matala.bpmn4s/src/nl/asml/matala/bpmn4s/bpmn4s/Bpmn4sCompiler.java
+++ b/bundles/nl.asml.matala.bpmn4s/src/nl/asml/matala/bpmn4s/bpmn4s/Bpmn4sCompiler.java
@@ -210,7 +210,7 @@ public class Bpmn4sCompiler{
 				String local = fabSpecLocal(c);
 				String init = fabSpecInit(c.getId());
 				List<String> sutConfVars = fabSpecSutConfs(c.getId());
-				String sutConfs = sutConfVars.isEmpty() ? "" : "sut-var: " + String.join(" ", sutConfVars) + "\n"; 
+				String sutConfs = sutConfVars.isEmpty() ? "" : "suts " + String.join(", ", sutConfVars) + "\n";
 				String desc = fabSpecDescription(c.getId()); 
 				component += indent(inOut);
 				component += "\n";

--- a/bundles/nl.asml.matala.bpmn4s/src/nl/asml/matala/bpmn4s/bpmn4s/Element.java
+++ b/bundles/nl.asml.matala.bpmn4s/src/nl/asml/matala/bpmn4s/bpmn4s/Element.java
@@ -62,6 +62,7 @@ public class Element {
 	 *  we consider this node an origin node.
 	 */
 	String originDataNodeId = null;
+	boolean isSutConfigurations = false;
 	
 	public Element(ElementType type) {
 		this.type = type;
@@ -106,6 +107,10 @@ public class Element {
 		return this;
 	}
 	
+	public String getId() {
+		return this.id;
+	}
+	
 	public String getOriginDataNodeId() {
 		if (this.isReferenceData()) {
 			return this.originDataNodeId;
@@ -118,12 +123,7 @@ public class Element {
 		this.originDataNodeId = id;
 		return this;
 	}
-	
-	public String getId() {
-		return this.id;
-	}
-	
-	
+		
 	public Element setStepType(String st) {
 		stepType = st;
 		return this;
@@ -235,6 +235,14 @@ public class Element {
 	
 	public String getInit() {
 		return init;
+	}
+	
+	public void setIsSutConfigurations(boolean conf) {
+		this.isSutConfigurations = conf;
+	}
+	
+	public boolean isSutConfigurations() {
+		return isSutConfigurations;
 	}
 	
 	// For action nodes

--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/Product.xtext
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/Product.xtext
@@ -58,8 +58,8 @@ Block:
 			('inputs' invars+=Variable* )? &
 			('outputs' outvars+=Variable* )? &
 			('local' localvars+=Variable* )? &
+            ('suts' sutvars += [expr::Variable|ID] (',' sutvars+=[expr::Variable|ID])*)? &
 			('init' initActions+=(AssignmentAction | RecordFieldAssignmentAction)*)? &
-			('sut-var' '{' sutVar += [expr::Variable|ID]* '}')? &
 			'desc' type = STRING
 		)
 		functions += Function*

--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/Product.xtext
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/Product.xtext
@@ -16,13 +16,8 @@ Product:
 	imports += Import*
 	(namespace += NameSpace)*
     types += TypeDecl*
-    (sutTypes = SUTTypeDecl)?
 	( systemDecl = SystemDecl	
 	| specification = Specification)
-;
-
-SUTTypeDecl:
-    'test-configuration-types' '{' type += Type+ '}'
 ;
 
 @Override
@@ -64,6 +59,7 @@ Block:
 			('outputs' outvars+=Variable* )? &
 			('local' localvars+=Variable* )? &
 			('init' initActions+=(AssignmentAction | RecordFieldAssignmentAction)*)? &
+			('sut-var' '{' sutVar += [expr::Variable|ID]* '}')? &
 			'desc' type = STRING
 		)
 		functions += Function*

--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/generator/PetriNet.xtend
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/generator/PetriNet.xtend
@@ -2,10 +2,11 @@ package nl.asml.matala.product.generator
 
 import java.util.ArrayList
 import java.util.HashMap
-import java.util.List
 import java.util.HashSet
-import nl.esi.comma.types.types.SimpleTypeDecl
+import java.util.List
+import java.util.Map
 import java.util.Set
+import nl.esi.comma.types.types.SimpleTypeDecl
 
 class PetriNet {
 	public var places = new ArrayList<Place>
@@ -322,14 +323,13 @@ class PetriNet {
 	def toSnakes(String prod_name, 
 				 String topology_name, 
 				 List<String> listOfEnvBlocks,
-				 ArrayList<String> listOfAssertTransitions,
-				 HashMap<String,List<String>> mapOfSuppressTransitionVars,
+				 List<String> listOfAssertTransitions,
+				 Map<String, ? extends List<String>> mapOfSuppressTransitionVars,
 				 List<String> inout_places, 
 				 List<String> init_places, 
 				 int depth_limit,
 				 int num_tests,
-				 List<String> sutVarList,
-				 HashMap<String, Set<String>> sutTransitionMap
+				 Map<String, ? extends Set<String>> sutTransitionMap
 	) {
 		'''
 		import datetime
@@ -367,7 +367,7 @@ class PetriNet {
 		    SavedMarking = Marking()
 		    
 		    # test generation data
-		    sutTypesList = [«FOR elm : sutVarList SEPARATOR ''','''»'«elm»'«ENDFOR»]
+		    sutTypesList = [«FOR elm : sutTransitionMap.keySet SEPARATOR ','»'«elm»'«ENDFOR»]
 		    sutVarTransitionMap = {}
 		    numTestCases = 0
 		    listOfEnvBlocks = []
@@ -397,7 +397,7 @@ class PetriNet {
 		    «print_SCNGen(num_tests, depth_limit)»
 		    
 		    def initializeTestGeneration(self):
-		        self.sutVarTransitionMap = {«FOR elm : sutTransitionMap.keySet SEPARATOR ','»'«elm»': [«FOR v : sutTransitionMap.get(elm) SEPARATOR ','»'«v»'«ENDFOR»]«ENDFOR»}
+		        self.sutVarTransitionMap = {«FOR entry : sutTransitionMap.entrySet SEPARATOR ','»'«entry.key»': [«FOR v : entry.value SEPARATOR ','»'«v»'«ENDFOR»]«ENDFOR»}
 		        # map_of_transition_modes = {}
 		        for entry in self.visitedTList:
 		            if entry:

--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/generator/PetriNet.xtend
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/generator/PetriNet.xtend
@@ -5,6 +5,7 @@ import java.util.HashMap
 import java.util.List
 import java.util.HashSet
 import nl.esi.comma.types.types.SimpleTypeDecl
+import java.util.Set
 
 class PetriNet {
 	public var places = new ArrayList<Place>
@@ -327,7 +328,8 @@ class PetriNet {
 				 List<String> init_places, 
 				 int depth_limit,
 				 int num_tests,
-				 List<String> sutTypesList
+				 List<String> sutVarList,
+				 HashMap<String, Set<String>> sutTransitionMap
 	) {
 		'''
 		import datetime
@@ -365,7 +367,8 @@ class PetriNet {
 		    SavedMarking = Marking()
 		    
 		    # test generation data
-		    sutTypesList = [«FOR elm : sutTypesList SEPARATOR ''','''»'«elm»'«ENDFOR»]
+		    sutTypesList = [«FOR elm : sutVarList SEPARATOR ''','''»'«elm»'«ENDFOR»]
+		    sutVarTransitionMap = {}
 		    numTestCases = 0
 		    listOfEnvBlocks = []
 		    listOfSUTActions = []
@@ -394,6 +397,7 @@ class PetriNet {
 		    «print_SCNGen(num_tests, depth_limit)»
 		    
 		    def initializeTestGeneration(self):
+		        self.sutVarTransitionMap = {«FOR elm : sutTransitionMap.keySet SEPARATOR ','»'«elm»': [«FOR v : sutTransitionMap.get(elm) SEPARATOR ','»'«v»'«ENDFOR»]«ENDFOR»}
 		        # map_of_transition_modes = {}
 		        for entry in self.visitedTList:
 		            if entry:
@@ -472,7 +476,7 @@ class PetriNet {
 		                    j = j + 1
 		                _test_scn.compute_dependencies()
 		                _test_scn.generate_viz(i, output_dir=p.plantuml_dir)
-		                _test_scn.generateTSpec(i, pn.sutTypesList, output_dir=p.tspec_dir)
+		                _test_scn.generateTSpec(i, pn.sutTypesList, pn.sutVarTransitionMap, output_dir=p.tspec_dir)
 		                _tests.list_of_test_scn.append(_test_scn)
 		            i = i + 1
 		            

--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/generator/ProductGenerator.xtend
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/generator/ProductGenerator.xtend
@@ -88,21 +88,20 @@ class ProductGenerator extends AbstractGenerator {
 	
 	def generatePetriNetAndTestGeneration(Product prod, Resource resource, IFileSystemAccess2 fsa) 
 	{	
-		var dataGetterTxt = (new TypesGenerator).generatePythonGetters(prod,resource)
+		val dataGetterTxt = (new TypesGenerator).generatePythonGetters(prod,resource)
 		var pnet = new PetriNet
 		var methodTxt = ''''''	
-		var sutVarList = new ArrayList<String>
-		var sutTransitionMap = new HashMap<String, Set<String>> // sutvar -> transition_list (occurs in input/output)
+		val sutTransitionMap = newLinkedHashMap // sutvar -> transition_list (occurs in input/output)
 
-		var inout_places = new ArrayList<String>
-		var init_places = new ArrayList<String>
+		val inout_places = newArrayList
+		val init_places = newArrayList
 		
-		var depth_limit = prod.specification.limit 
+		val depth_limit = prod.specification.limit 
 		
-		var num_tests = prod.specification.numTests
+		val num_tests = prod.specification.numTests
 		
-		var import_list = new ArrayList<String>
-		var var_decl_map = new HashMap<String,String>
+		val import_list = newArrayList
+		val var_decl_map = newLinkedHashMap
 		
 		/* Generate Z3 Data Types */
 		for(imp : prod.imports) {
@@ -129,9 +128,8 @@ class ProductGenerator extends AbstractGenerator {
 			for(ovar : block.outvars) var_decl_map.put(block.name + "_" + ovar.name, ovar.type.type.name)
 			for(lvar : block.localvars) var_decl_map.put(block.name + "_" + lvar.name, lvar.type.type.name)
 			// Added DB 15.04.2025. To handle SUT Variables List
-            for(sutvar : block.sutVar) {
-                sutVarList.add(sutvar.name)
-                sutTransitionMap.put(sutvar.name, new HashSet<String>)
+            for(sutvar : block.sutvars) {
+                sutTransitionMap.put(sutvar.name, newLinkedHashSet)
             }
 			
 			// parse each block to derive places and transitions
@@ -228,7 +226,7 @@ class ProductGenerator extends AbstractGenerator {
 			fsa.generateFile('CPNServer//' + prod.specification.name + '//' + name + '.py', pnet.toSnakes(
 			    name, name, listOfEnvBlocks, listOfAssertTransitions, 
 			    mapOfSuppressTransitionVars, inout_places, 
-			    init_places, depth_limit, num_tests, sutVarList, sutTransitionMap
+			    init_places, depth_limit, num_tests, sutTransitionMap
 			))
 			//fsa.generateFile('CPNServer//' + prod.specification.name + '//' + 'server.py', (new FlaskSimulationGenerator).generateServer(name))
 			//fsa.generateFile('CPNserver.py', (new FlaskSimulationGenerator).generateCPNServer)

--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/generator/Utils.xtend
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/generator/Utils.xtend
@@ -425,16 +425,11 @@ class Utils
                     txt += "}\n"
                 return txt
                 
-            def generateTSpec(self, idx, sutTypesList, output_dir):
+            def generateTSpec(self, idx, sutTypesList, sutVarTransitionMap, output_dir):
                 txt = ""
                 txt += "import \"«pSpecFile»\"\n\n"
                 «(new Utils()).usageList(prod)»
                 txt += "\nabstract-test-definition\n\n"
-                if sutTypesList:
-                    txt += "\ntest-configuration-types {"
-                    for typ in sutTypesList:
-                        txt += "\n\t" + typ
-                    txt += "\n}\n\n"
                 txt += "Test-Scenario: S%s\n" % idx
                 for step in self.step_list:
                     if not step.is_assert:
@@ -443,6 +438,7 @@ class Utils
                         odata = step.output_data
                         parts = name.split("@")
                         new_name = parts[0] + parts[3]
+                        raw_name = parts[0]
                         if "RUN" in parts[2]:
                             type_name = ""
                             if not "null" in parts[1]:
@@ -461,7 +457,12 @@ class Utils
                                 txt += " }\n"
                         txt += "input-binding:\n"
                         txt += self.printData(idata)
+                        isSutVarPresent = False
                         for k, v in idata.items():
+                            if k in sutVarTransitionMap:
+                                for tr in sutVarTransitionMap[k]:
+                                    if tr == raw_name:
+                                       isSutVarPresent = True
                             if name.rsplit("_",1)[0] in self.constraint_dict:
                                 for constr in self.constraint_dict[name.rsplit("_",1)[0]]:
                                     if constr.var_ref == k and constr.dir == "IN":
@@ -473,6 +474,10 @@ class Utils
                         # if step.is_suppress:
                         # txt += "suppress\n"
                         for k, v in odata.items():
+                            if k in sutVarTransitionMap:
+                                for tr in sutVarTransitionMap[k]:
+                                    if tr == raw_name:
+                                       isSutVarPresent = True
                             if name.rsplit("_",1)[0] in self.constraint_dict:
                                 for constr in self.constraint_dict[name.rsplit("_",1)[0]]:
                                     if constr.var_ref == k and constr.dir == "OUT":
@@ -482,7 +487,12 @@ class Utils
                         if name.rsplit("_",1)[0] in self.tr_assert_ref_dict.keys():
                             txt += "output-assertion: %s\n" % new_name
                             txt += "%s\n" % self.tr_assert_ref_dict[name.rsplit("_",1)[0]]
-                    else:
+                        if isSutVarPresent:
+                            txt += "sut-var: { "
+                            for _v in sutVarTransitionMap:
+                                txt += "%s " % _v
+                            txt += " }\n"
+                    else: # deprecated branch.
                         name = step.step_name
                         idata = step.input_data
                         odata = step.output_data

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/Testspecification.xtext
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/Testspecification.xtext
@@ -66,14 +66,10 @@ TMap:
 
 /*********************************************************/
 AbstractTestSequence:
-	(sutTypes = SUTTypeDecl)?
+	// (sutTypes = SUTTypeDecl)?
 	'Test-Scenario' ':' name = ID
 		// step += [TMap|ID]+
 		step += AbstractStep+ // (AbstractStep | AssertStep)+  // | ConstraintStep 
-;
-
-SUTTypeDecl:
-    'test-configuration-types' '{' type += Type+ '}'
 ;
 
 ConstraintStep:
@@ -102,6 +98,7 @@ ComposeStep:
 	'input-binding' ':' input += Binding+
 	'output-data' ':' output += Binding+ (suppress?='suppress'?)
 	refs += ConstraintStep*
+	('sut-var' ':' '{' varID += [expr::Variable|QualifiedName]+ '}')?
 ;
 
 RunStep:
@@ -110,6 +107,7 @@ RunStep:
 	stepRef += StepReference*
 	'input-binding' ':' input += Binding+
 	'output-data' ':' output += Binding+ (suppress?='suppress'?) // do not generate these in concrete TSpec
+	('sut-var' ':' '{' varID += [expr::Variable|QualifiedName]+ '}')?
 ;
 
 AssertionStep:
@@ -118,6 +116,7 @@ AssertionStep:
     'input-binding' ':' input += Binding+
     'output-data' ':' output += Binding+ (suppress?='suppress'?)
     asserts += AssertStep*
+    ('sut-var' ':' '{' varID += [expr::Variable|QualifiedName]+ '}')?
 ;
 
 StepReference:

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/Testspecification.xtext
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/Testspecification.xtext
@@ -66,7 +66,6 @@ TMap:
 
 /*********************************************************/
 AbstractTestSequence:
-	// (sutTypes = SUTTypeDecl)?
 	'Test-Scenario' ':' name = ID
 		// step += [TMap|ID]+
 		step += AbstractStep+ // (AbstractStep | AssertStep)+  // | ConstraintStep 


### PR DESCRIPTION
Closes #86: support for SUT configurations on the transformer from bpmn4s to pspec.

@Yuri-Blankenstein-TNO I assume that if I mark a datastore as a sutconfiguration, all its linked datastores are also marked as such. I also assume that the property of the bpmn(xml) element is called "sutConfigurations". Hope this is correct? 