### PR TITLE
90 add simulator installation instructions to readme

### DIFF
--- a/bundles/nl.asml.matala.product.lsp.server/dist/README.md
+++ b/bundles/nl.asml.matala.product.lsp.server/dist/README.md
@@ -19,8 +19,10 @@ pip install snakes
 pip install flask flask_cors
 ```
 
-Next, you must define a (local user) environment variable named ``BPMN4S_PYTHON`` 
-pointing to the ``python.exe`` of your Python 3.10+ virtual environment.
+Next, you can define a environment variable named ``BPMN4S_PYTHON`` pointing to an alternative ``python.exe``.
+This environment variable will be used to start the simulation server.
+If ``BPMN4S_PYTHON`` is not defined, the standard ``python.exe`` will be used.
+
 
 ### Running the simulation server
 

--- a/bundles/nl.asml.matala.product.lsp.server/dist/README.md
+++ b/bundles/nl.asml.matala.product.lsp.server/dist/README.md
@@ -11,7 +11,7 @@ Please keep this console open during your BPMN4S modeling sessions, and just clo
 
 ## Starting the simulation server
 
-### _Pre-requisites for running the simulation environment_
+### Pre-requisites for running the simulation environment (One time only!)
 To run the simulation server, you need ``python v3.10 (or greater)`` and the following modules:
 
 ```

--- a/bundles/nl.asml.matala.product.lsp.server/dist/README.md
+++ b/bundles/nl.asml.matala.product.lsp.server/dist/README.md
@@ -22,7 +22,7 @@ pip install flask flask_cors
 Next, you must define a (local user) environment variable named ``BPMN4S_PYTHON`` 
 pointing to the ``python.exe`` of your Python 3.10+ virtual environment.
 
-### _Running the simulation server_
+### Running the simulation server
 
 To get simulation capabilities enabled, the CPNServer needs to be started before starting a token simulation.
 To start the CPN server, simply execute the `start-simulator.bat` file by double clicking it.

--- a/bundles/nl.asml.matala.product.lsp.server/dist/README.md
+++ b/bundles/nl.asml.matala.product.lsp.server/dist/README.md
@@ -11,6 +11,19 @@ Please keep this console open during your BPMN4S modeling sessions, and just clo
 
 ## Starting the simulation server
 
+### _Pre-requisites for running the simulation environment_
+To run the simulation server, you need ``python v3.10 (or greater)`` and the following modules:
+
+```
+pip install snakes 
+pip install flask flask_cors
+```
+
+Next, you must define a (local user) environment variable named ``BPMN4S_PYTHON`` 
+pointing to the ``python.exe`` of your Python 3.10+ virtual environment.
+
+### _Running the simulation server_
+
 To get simulation capabilities enabled, the CPNServer needs to be started before starting a token simulation.
 To start the CPN server, simply execute the `start-simulator.bat` file by double clicking it.
 This will open a console, and if correct, the console will state: `... Running on http://127.0.0.1:5000`

--- a/bundles/nl.esi.comma.project.standard.cli/dist/start-simulator.bat
+++ b/bundles/nl.esi.comma.project.standard.cli/dist/start-simulator.bat
@@ -1,21 +1,27 @@
 @ECHO OFF
 SETLOCAL
 
-echo Using python environment: %BPMN4S_PYTHON%
-
 IF not defined BPMN4S_PYTHON (
-  ECHO BPMN4S_PYTHON variable is NOT defined >&2
-  pause
-  exit
+  ECHO *-----------------------------------------* >&2
+  ECHO * BPMN4S_PYTHON variable is NOT defined!  * >&2
+  ECHO * Standard python.exe will be used.       * >&2
+  ECHO *-----------------------------------------* >&2
+  ECHO:
+  set BPMN4S_PYTHON=python.exe
 )
+ 
+ECHO # Using python environment: "%BPMN4S_PYTHON%"
 
 FOR /F "delims=" %%i IN ("%~dp0") DO (
   set script_drive=%%~di
   set script_path=%%~pi
 )
-set simulator_file=%script_drive%%script_path%\simulator\CPNServer.py
-echo Starting simulator:  %simulator_file%
+set simulator_file=%script_drive%%script_path%simulator\CPNServer.py
+ECHO # Starting simulator:  "%simulator_file%" 
+ECHO:
 
 %BPMN4S_PYTHON% "%simulator_file%"
+
+ENDLOCAL
 
 pause

--- a/bundles/nl.esi.comma.project.standard.cli/dist/start-simulator.bat
+++ b/bundles/nl.esi.comma.project.standard.cli/dist/start-simulator.bat
@@ -1,11 +1,18 @@
 @ECHO OFF
 SETLOCAL
 
+echo Using python environment: %BPMN4S_PYTHON%
+
+IF not defined BPMN4S_PYTHON (
+  ECHO BPMN4S_PYTHON variable is NOT defined >&2
+  pause
+  exit
+)
+
 FOR /F "delims=" %%i IN ("%~dp0") DO (
   set script_drive=%%~di
   set script_path=%%~pi
 )
-
 set simulator_file=%script_drive%%script_path%\simulator\CPNServer.py
 echo Starting simulator:  %simulator_file%
 

--- a/bundles/nl.esi.comma.project.standard.cli/dist/start-simulator.bat
+++ b/bundles/nl.esi.comma.project.standard.cli/dist/start-simulator.bat
@@ -9,6 +9,6 @@ FOR /F "delims=" %%i IN ("%~dp0") DO (
 set simulator_file=%script_drive%%script_path%\simulator\CPNServer.py
 echo Starting simulator:  %simulator_file%
 
-python "%simulator_file%"
+%BPMN4S_PYTHON% "%simulator_file%"
 
 pause


### PR DESCRIPTION
- [x] added python instructions for installation and venv to README
- [x] start-simulator batch script optionally uses python venv set in windows environment variable ``%BPMN4S_PYTHON%``, otherwise it uses ``python.exe``