### PR TITLE
Validation prevent duplicate actions

### DIFF
--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/generator/ValidationHelper.xtend
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/generator/ValidationHelper.xtend
@@ -1,0 +1,50 @@
+package nl.asml.matala.product.generator
+
+import nl.esi.comma.expressions.expression.Expression
+import nl.esi.comma.actions.actions.Action
+import nl.esi.comma.actions.actions.RecordFieldAssignmentAction
+import nl.esi.comma.expressions.expression.ExpressionRecordAccess
+import nl.esi.comma.expressions.generator.ExpressionsCommaGenerator
+import nl.esi.comma.actions.actions.AssignmentAction
+import nl.esi.comma.actions.actions.IfAction
+import nl.esi.comma.actions.actions.ForAction
+
+class ValidationHelper {
+
+    /**
+     * Get variables based on the action type
+     * */
+    
+    def static Pair<String, Expression> getActionVariables(Action actionType) {
+        switch (actionType) {
+            AssignmentAction: {
+                return getAssignmentActionVar(actionType);
+            }
+            RecordFieldAssignmentAction: {
+                val access = actionType.getFieldAccess() as ExpressionRecordAccess;
+                val record = (new ExpressionsCommaGenerator()).exprToComMASyntax(access.getRecord()).toString();
+                val rhsExp = actionType.getExp() as Expression;
+                return new Pair<String, Expression>(record, rhsExp);
+            }
+            IfAction: {
+                for (a : actionType.getThenList().getActions()) {
+                    return getActionVariables(a);
+                }
+                if (actionType.getElseList() !== null) {
+                    for (a : actionType.getElseList().getActions()) {
+                        return getActionVariables(a);
+                    }
+                }
+            }
+            ForAction: {
+                for (a : actionType.getDoList().getActions()) {
+                    return getActionVariables(a);
+                }
+            }
+        }
+    }
+
+    def static Pair<String, Expression> getAssignmentActionVar(AssignmentAction AssinmentExpression) {
+        return new Pair<String, Expression>(AssinmentExpression.getAssignment().getName(), AssinmentExpression.getExp())
+    }
+}

--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/validation/ProductValidator.xtend
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/validation/ProductValidator.xtend
@@ -8,108 +8,132 @@ import nl.esi.comma.types.types.TypesPackage
 import org.eclipse.emf.common.util.URI
 import org.eclipse.xtext.EcoreUtil2
 import org.eclipse.xtext.validation.Check
+import nl.asml.matala.product.product.Function
+import java.util.HashSet
+import nl.asml.matala.product.product.ProductPackage
+import nl.asml.matala.product.product.Update
 
 /**
  * This class contains custom validation rules. 
- *
+ * 
  * See https://www.eclipse.org/Xtext/documentation/303_runtime_concepts.html#validation
  */
 class ProductValidator extends AbstractProductValidator {
-	@Check
+
+    @Check
     override checkImportForValidity(Import imp) {
-        if(!EcoreUtil2.isValidUri(imp, URI.createURI(imp.getImportURI()))) {
+        if (!EcoreUtil2.isValidUri(imp, URI.createURI(imp.getImportURI()))) {
             error("Invalid resource", imp, TypesPackage.eINSTANCE.getImport_ImportURI());
         } else {
             /*val Resource r = EcoreUtil2.getResource(imp.eResource, imp.importURI)
-            if(! (r.allContents.head instanceof InterfaceDefinition ||
-                r.allContents.head instanceof FeatureDefinition
-            ))
-                error("The imported resource is not an interface definition or a feature definition.", imp, TypesPackage.eINSTANCE.import_ImportURI)
-        }*/
+             * if(! (r.allContents.head instanceof InterfaceDefinition ||
+             *     r.allContents.head instanceof FeatureDefinition
+             * ))
+             *     error("The imported resource is not an interface definition or a feature definition.", imp, TypesPackage.eINSTANCE.import_ImportURI)
+             }*/
         }
     }
-    
-    
-    /* STRANGE BUG: Output Vars are Empty. Appears in Input Vars. 
-     * Not appearing as problem during product generation!
-    */
-    /*
+
+    /**
+     * Prevent Duplicate Updates in Actions
+     */
     @Check
-    public void checkInputOutputMapping(Product p) 
-    {
-        var outVarMap = new HashMap<String,List<String>>();
-        var inVarMap  = new HashMap<String,List<String>>();
-        
-        for(var b : p.getBlock()) {
-            System.out.println(" + Parsing Block: " + b.getName());
-            for(var ov : b.getOutvars()) {
-                if(outVarMap.containsKey(b.getName())) {
-                    outVarMap.get(b.getName()).add(ov.getName());
-                    System.out.println("    Added Output: " + ov.getName());
-                }
-                else {
-                    var lst = new ArrayList<String>();
-                    lst.add(ov.getName());
-                    outVarMap.put(b.getName(), lst);
-                    System.out.println("    Added Output to Existing: " + ov.getName());
-                }
-            }
-            for(var iv : b.getInvars()) {
-                System.out.println(" - Parsing Block: " + b.getName());
-                if(inVarMap.containsKey(b.getName())) {
-                    inVarMap.get(b.getName()).add(iv.getName());
-                    System.out.println("    Added Input: " + iv.getName());
-                }
-                else {
-                    var lst = new ArrayList<String>();
-                    lst.add(iv.getName());
-                    inVarMap.put(b.getName(), lst);
-                    System.out.println("    Added Input to Existing: " + iv.getName());
+    def preventDuplicationUpdatesActions(Function function) {
+        for (update : function.updates) {
+            val groupedByName = update.updateOutputVar.flatMap[it.fnOut].groupBy[it.ref.name]
+
+            for (e : groupedByName.entrySet) {
+                if (e.value.size > 1) {
+                    for (output : e.value) {
+                        error(
+                            "Duplicate output variable name: " + output.ref.name,
+                            ProductPackage.Literals.FUNCTION__UPDATES
+                        )
+                    }
+
                 }
             }
         }
-        
-        System.out.println(" Debug in Var: " + inVarMap);
-        System.out.println(" Debug out Var: " + outVarMap);
-        
-        for(var t : p.getTopology()) {
-            for(var f : t.getFlow()) {
-                for(var conn : f.getVarConn()) {
-                    var lkey = conn.getVarRefLHS().getBlockRef().getName();
-                    var lvalue = conn.getVarRefLHS().getVarRef().getName();
-                    var rkey = conn.getVarRefRHS().getBlockRef().getName();
-                    var rvalue = conn.getVarRefRHS().getVarRef().getName();
-                    inVarMap.get(lkey).remove(lvalue);
-                    outVarMap.get(rkey).remove(rvalue);
-                }
-            }
-        }
-        
-        System.out.println(" Debug in Var: " + inVarMap);
-        System.out.println(" Debug out Var: " + outVarMap);
-        
-        // Check what is not mapped. 
-        var txt = new String();
-        var isUnMapped = false;
-        
-        for(var k : inVarMap.keySet()) {
-            if(!inVarMap.get(k).isEmpty()) {
-                isUnMapped = true;
-                txt += "\n block: " + k + " has input: "+ inVarMap.get(k) + "with no source \n";
-            }
-        }
-        
-        for(var k : outVarMap.keySet()) {
-            if(!outVarMap.get(k).isEmpty()) {
-                isUnMapped = true;
-                txt += "\n block: " + k + " has output: "+ outVarMap.get(k) + "with no target \n";
-            }
-        }
-        
-        if(isUnMapped) {
-            error("Missing Input-Output Connections: \n" + txt, 
-                    ProductPackage.Literals.PRODUCT__TOPOLOGY);
-        }
-    }*/
-	
+    }
+/* STRANGE BUG: Output Vars are Empty. Appears in Input Vars. 
+ * Not appearing as problem during product generation!
+ */
+/*
+ * @Check
+ * public void checkInputOutputMapping(Product p) 
+ * {
+ *     var outVarMap = new HashMap<String,List<String>>();
+ *     var inVarMap  = new HashMap<String,List<String>>();
+ *     
+ *     for(var b : p.getBlock()) {
+ *         System.out.println(" + Parsing Block: " + b.getName());
+ *         for(var ov : b.getOutvars()) {
+ *             if(outVarMap.containsKey(b.getName())) {
+ *                 outVarMap.get(b.getName()).add(ov.getName());
+ *                 System.out.println("    Added Output: " + ov.getName());
+ *             }
+ *             else {
+ *                 var lst = new ArrayList<String>();
+ *                 lst.add(ov.getName());
+ *                 outVarMap.put(b.getName(), lst);
+ *                 System.out.println("    Added Output to Existing: " + ov.getName());
+ *             }
+ *         }
+ *         for(var iv : b.getInvars()) {
+ *             System.out.println(" - Parsing Block: " + b.getName());
+ *             if(inVarMap.containsKey(b.getName())) {
+ *                 inVarMap.get(b.getName()).add(iv.getName());
+ *                 System.out.println("    Added Input: " + iv.getName());
+ *             }
+ *             else {
+ *                 var lst = new ArrayList<String>();
+ *                 lst.add(iv.getName());
+ *                 inVarMap.put(b.getName(), lst);
+ *                 System.out.println("    Added Input to Existing: " + iv.getName());
+ *             }
+ *         }
+ *     }
+ *     
+ *     System.out.println(" Debug in Var: " + inVarMap);
+ *     System.out.println(" Debug out Var: " + outVarMap);
+ *     
+ *     for(var t : p.getTopology()) {
+ *         for(var f : t.getFlow()) {
+ *             for(var conn : f.getVarConn()) {
+ *                 var lkey = conn.getVarRefLHS().getBlockRef().getName();
+ *                 var lvalue = conn.getVarRefLHS().getVarRef().getName();
+ *                 var rkey = conn.getVarRefRHS().getBlockRef().getName();
+ *                 var rvalue = conn.getVarRefRHS().getVarRef().getName();
+ *                 inVarMap.get(lkey).remove(lvalue);
+ *                 outVarMap.get(rkey).remove(rvalue);
+ *             }
+ *         }
+ *     }
+ *     
+ *     System.out.println(" Debug in Var: " + inVarMap);
+ *     System.out.println(" Debug out Var: " + outVarMap);
+ *     
+ *     // Check what is not mapped. 
+ *     var txt = new String();
+ *     var isUnMapped = false;
+ *     
+ *     for(var k : inVarMap.keySet()) {
+ *         if(!inVarMap.get(k).isEmpty()) {
+ *             isUnMapped = true;
+ *             txt += "\n block: " + k + " has input: "+ inVarMap.get(k) + "with no source \n";
+ *         }
+ *     }
+ *     
+ *     for(var k : outVarMap.keySet()) {
+ *         if(!outVarMap.get(k).isEmpty()) {
+ *             isUnMapped = true;
+ *             txt += "\n block: " + k + " has output: "+ outVarMap.get(k) + "with no target \n";
+ *         }
+ *     }
+ *     
+ *     if(isUnMapped) {
+ *         error("Missing Input-Output Connections: \n" + txt, 
+ *                 ProductPackage.Literals.PRODUCT__TOPOLOGY);
+ *     }
+ }*/
 }

--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/validation/ProductValidator.xtend
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/validation/ProductValidator.xtend
@@ -12,6 +12,7 @@ import nl.asml.matala.product.product.Function
 import java.util.HashSet
 import nl.asml.matala.product.product.ProductPackage
 import nl.asml.matala.product.product.Update
+import nl.asml.matala.product.product.Block
 
 /**
  * This class contains custom validation rules. 
@@ -34,9 +35,11 @@ class ProductValidator extends AbstractProductValidator {
         }
     }
 
+
     /**
      * Prevent Duplicate Updates in Actions
      */
+     
     @Check
     def preventDuplicationUpdatesActions(Function function) {
         for (update : function.updates) {
@@ -55,6 +58,60 @@ class ProductValidator extends AbstractProductValidator {
             }
         }
     }
+
+
+
+    /**
+     * Check the duplication of variables in Inputs
+     */
+    @Check
+    def checkInputDuplication(Block block) {
+        val existingInputs = block.invars.groupBy[input|input.name]
+        for (entry : existingInputs.entrySet) {
+            if (entry.value.size > 1) {
+                for (input : entry.value) {
+                    error("Duplicate variable name in inputs : " + input.name, ProductPackage.Literals.BLOCK__INVARS,
+                        block.invars.indexOf(input))
+                }
+            }
+
+        }
+    }
+
+
+
+    /**
+     * Check the duplication of variables in Outputs
+     */
+    @Check
+    def checkOutputDuplication(Block block) {
+        val existingOutputs = block.outvars.groupBy[output|output.name]
+        for (entry : existingOutputs.entrySet) {
+            if (entry.value.size > 1) {
+                for (output : entry.value) {
+                    error("Duplicate variable name in outputs : " + output.name, ProductPackage.Literals.BLOCK__OUTVARS,
+                        block.outvars.indexOf(output))
+                }
+            }
+        }
+    }
+
+    /**
+     * Check the duplication of variables in Local
+     */
+    @Check
+    def checkLocalDuplication(Block block) {
+        val existingLocalvars = block.localvars.groupBy[localvars|localvars.name]
+        for (entry : existingLocalvars.entrySet) {
+            if (entry.value.size > 1) {
+                for (localvars : entry.value) {
+                    error("Duplicate variable name in local variables : " + localvars.name,
+                        ProductPackage.Literals.BLOCK__LOCALVARS, block.localvars.indexOf(localvars))
+                }
+            }
+        }
+    }
+
 /* STRANGE BUG: Output Vars are Empty. Appears in Input Vars. 
  * Not appearing as problem during product generation!
  */


### PR DESCRIPTION
This branch was created for the issue "Prevent Duplicate Updates in Actions." Previous branches showed unclear merge conflicts with main. Since only two files were modified across all branches, I have consolidated all changes into this branch. 

For the issue "Prevent Duplicate Updates in Actions" , We want to prevent the ambiguous definitions of multiple updates to the same output variable in actions. 
To address this, I implemented a function called preventDuplicationUpdatesActions.

The rest of the file had already been reviewed, and the necessary changes have been applied. 
