### PR TITLE
Assertion output and script input parameters respectively prefixed with ['step_output'] and ['matlab_call'] 

### DIFF
--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/Product.xtext
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/Product.xtext
@@ -123,7 +123,8 @@ SymbConstraint:
 
 DataAssertions: {DataAssertions}
     'assertions' name = ID '{' 
-        constr += DataAssertionItem*
+        script += GenericScriptBlock*
+        constr += AssertThatBlock*
      '}'
 ;
 

--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/Product.xtext
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/Product.xtext
@@ -123,8 +123,7 @@ SymbConstraint:
 
 DataAssertions: {DataAssertions}
     'assertions' name = ID '{' 
-        script += GenericScriptBlock*
-        constr += AssertThatBlock*
+        constr += DataAssertionItem+
      '}'
 ;
 

--- a/bundles/nl.esi.comma.assertthat/src/nl/esi/comma/assertthat/AssertThat.xtext
+++ b/bundles/nl.esi.comma.assertthat/src/nl/esi/comma/assertthat/AssertThat.xtext
@@ -31,7 +31,7 @@ ScriptParameterNamedPositional:
 
 ScriptParameterNamed: ScriptParameterNameOnly | ScriptParameterNamedArg ;
 ScriptParameterPositional: ScriptParameterPositionalFile | ScriptParameterPositionalSimple ;
-ScriptParameterWithValue: ScriptParameterNamedArg | ScriptParameterPositionalFile | ScriptParameterPositional ;
+ScriptParameterWithValue: ScriptParameterNamedArg | ScriptParameterPositional ;
 
 ScriptParameterNameOnly: "flag-argument"  "{" label=STRING "}" ;
 ScriptParameterNamedArg: "named-argument" "{" label=STRING "," val=Expression (file?="is-file")? "}" ;

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/RefKVPGenerator.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/RefKVPGenerator.xtend
@@ -1,8 +1,5 @@
 package nl.esi.comma.testspecification.abstspec.generator
 
-import java.util.ArrayList
-import org.eclipse.emf.common.util.EList
-
 import nl.esi.comma.assertthat.assertThat.AssertThatBlock
 import nl.esi.comma.assertthat.assertThat.AssertThatValue
 import nl.esi.comma.assertthat.assertThat.AssertThatValueClose
@@ -19,7 +16,6 @@ import nl.esi.comma.assertthat.assertThat.ComparisonsForSingleReference
 import nl.esi.comma.assertthat.assertThat.GenericScriptBlock
 import nl.esi.comma.assertthat.assertThat.MARGIN_TYPE
 import nl.esi.comma.assertthat.assertThat.MargingItem
-import nl.esi.comma.testspecification.testspecification.AbstractStep
 import nl.esi.comma.testspecification.testspecification.AbstractTestDefinition
 import nl.esi.comma.testspecification.testspecification.AssertionStep
 import nl.esi.comma.expressions.expression.Expression

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/RefKVPGenerator.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/RefKVPGenerator.xtend
@@ -46,7 +46,7 @@ class RefKVPGenerator {
             «FOR step : testseq.step.filter(AssertionStep) »
             «FOR asrtce : step.asserts » 
             «FOR ce : asrtce.ce»
-                «FOR mlcal : step.asserts.flatMap[ce].flatMap[constr].filter(GenericScriptBlock) SEPARATOR ',' »
+                «FOR mlcal : ce.constr.filter(GenericScriptBlock) SEPARATOR ',' »
                 {
                     "id":"«mlcal.assignment.name»", 
                     "script_path":"«mlcal.params.scriptApi»",

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/RefKVPGenerator.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/RefKVPGenerator.xtend
@@ -43,7 +43,7 @@ class RefKVPGenerator {
         '''
         matlab_calls=[
         «FOR testseq : atd.testSeq»
-            «FOR step : testseq.step.filter(AssertionStep) »
+            «FOR step : atd.testSeq.flatMap[testseq].step.filter(AssertionStep) »
             «FOR asrtce : step.asserts » 
             «FOR ce : asrtce.ce»
                 «FOR mlcal : step.asserts.flatMap[ce].flatMap[constr].filter(GenericScriptBlock) SEPARATOR ',' »

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/RefKVPGenerator.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/RefKVPGenerator.xtend
@@ -44,7 +44,8 @@ class RefKVPGenerator {
         matlab_calls=[
         «FOR testseq : atd.testSeq»
             «FOR step : testseq.step.filter(AssertionStep) »
-            «FOR asrtce : step.asserts » «FOR ce : asrtce.ce»
+            «FOR asrtce : step.asserts » 
+            «FOR ce : asrtce.ce»
                 «FOR mlcal : ce.constr.filter(GenericScriptBlock) SEPARATOR ',' »
                 {
                     "id":"«mlcal.assignment.name»", 
@@ -65,7 +66,8 @@ class RefKVPGenerator {
                     ]
                 }
                 «ENDFOR»
-            «ENDFOR»«ENDFOR»
+            «ENDFOR»
+            «ENDFOR»
             «ENDFOR»
         «ENDFOR»
         ]
@@ -73,7 +75,8 @@ class RefKVPGenerator {
         assertions = [
         «FOR testseq : atd.testSeq»
             «FOR step : testseq.step.filter(AssertionStep) » 
-            «FOR asrtce : step.asserts » «FOR ce : asrtce.ce»
+            «FOR asrtce : step.asserts »
+            «FOR ce : asrtce.ce»
                 «FOR asrt : ce.constr.filter(AssertThatBlock) SEPARATOR ',' »
                 {
                     "id":"«asrt.identifier»", "type":"«getAssertionType(asrt.^val)»",
@@ -83,7 +86,8 @@ class RefKVPGenerator {
                     }
                 }
                 «ENDFOR»
-            «ENDFOR»«ENDFOR»
+            «ENDFOR»
+            «ENDFOR»
             «ENDFOR»
         «ENDFOR»
         ]

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/RefKVPGenerator.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/RefKVPGenerator.xtend
@@ -43,7 +43,7 @@ class RefKVPGenerator {
         '''
         matlab_calls=[
         «FOR testseq : atd.testSeq»
-            «FOR step : atd.testSeq.flatMap[testseq].step.filter(AssertionStep) »
+            «FOR step : testseq.step.filter(AssertionStep) »
             «FOR asrtce : step.asserts » 
             «FOR ce : asrtce.ce»
                 «FOR mlcal : step.asserts.flatMap[ce].flatMap[constr].filter(GenericScriptBlock) SEPARATOR ',' »

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/RefKVPGenerator.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/RefKVPGenerator.xtend
@@ -206,15 +206,11 @@ class RefKVPGenerator {
      */
     def String extractAssertionParams(AssertValidation params, AssertionStep step) {
         switch (params){
-            AssertThatValue:   return extractAssertionParams(params)
+            AssertThatValue:   return extractAssertionParams(params.comparisonType)
             AssertThatXPaths:  return extractAssertionParams(params)
             AssertThatXMLFile: return extractAssertionParams(params, step)
         }
         throw new RuntimeException("Not supported")
-    }
-
-    def String extractAssertionParams(AssertThatValue params) {
-        return extractAssertionParams(params.comparisonType)
     }
 
     /**

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/RefKVPGenerator.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/RefKVPGenerator.xtend
@@ -46,7 +46,7 @@ class RefKVPGenerator {
             «FOR step : testseq.step.filter(AssertionStep) »
             «FOR asrtce : step.asserts » 
             «FOR ce : asrtce.ce»
-                «FOR mlcal : ce.constr.filter(GenericScriptBlock) SEPARATOR ',' »
+                «FOR mlcal : step.asserts.flatMap[ce].flatMap[constr].filter(GenericScriptBlock) SEPARATOR ',' »
                 {
                     "id":"«mlcal.assignment.name»", 
                     "script_path":"«mlcal.params.scriptApi»",

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/RefKVPGenerator.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/RefKVPGenerator.xtend
@@ -272,6 +272,7 @@ class RefKVPGenerator {
     }
     def String extractAssertionParams(AssertThatXMLFile xmlfile) {
         return '''
+        "reference":«expression(xmlfile.reference,"")»,
         "xpaths":[
                 «FOR anAssert : xmlfile.assertRef SEPARATOR ","»
                     {


### PR DESCRIPTION
Completed code for generating ref.kvps by prefixing references to variables coming from _Run steps_ and _matlab_calls_