### PR TITLE
enabling bpmn4scompiler to generate assert-tasks

### DIFF
--- a/bundles/nl.asml.matala.bpmn4s/src/nl/asml/matala/bpmn4s/bpmn4s/Bpmn4s.java
+++ b/bundles/nl.asml.matala.bpmn4s/src/nl/asml/matala/bpmn4s/bpmn4s/Bpmn4s.java
@@ -70,6 +70,10 @@ public class Bpmn4s {
 	public Boolean isRunTask(String id) {
 		return elements.containsKey(id) && elements.get(id).getSubType().equals(ElementType.RUN_TASK);
 	}
+
+	public Boolean isAssertTask(String id) {
+		return elements.containsKey(id) && elements.get(id).getSubType().equals(ElementType.ASSERT_TASK);
+	}
 	
 	public Boolean isComposeTask(String id) {
 		return elements.containsKey(id) && elements.get(id).getSubType().equals(ElementType.COMPOSE_TASK);

--- a/bundles/nl.asml.matala.bpmn4s/src/nl/asml/matala/bpmn4s/bpmn4s/Bpmn4sCompiler.java
+++ b/bundles/nl.asml.matala.bpmn4s/src/nl/asml/matala/bpmn4s/bpmn4s/Bpmn4sCompiler.java
@@ -501,6 +501,8 @@ public class Bpmn4sCompiler{
 					String stepConf = "";
 					if (model.isComposeTask(node.getId())) {
 						stepConf = String.format(" step-type \"%s\" action-type COMPOSE", node.getStepType());
+					} else if(model.isAssertTask(node.getId())) {
+						stepConf = String.format(" step-type \"%s\" action-type ASSERT", node.getStepType());
 					} else if(model.isRunTask(node.getId())) {
 						stepConf = String.format(" step-type \"%s\" action-type RUN", node.getStepType());
 					}


### PR DESCRIPTION
I noticed that the .ps files derived from .bpmn models did not include a marking that a task is of type assert-task.

These changes should indicate assert-tasks as such also in .ps files.