### PR TITLE
Script-call (assertion) is identified by variable-name (assertion label) + step in which they are located

### DIFF
--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/AssertionsHelper.java
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/AssertionsHelper.java
@@ -12,11 +12,12 @@
  */
 package nl.esi.comma.testspecification.abstspec.generator;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.eclipse.emf.ecore.EObject;
+
+import nl.esi.comma.assertthat.assertThat.GenericScriptBlock;
 import nl.esi.comma.expressions.expression.Expression;
 import nl.esi.comma.expressions.expression.ExpressionBracket;
 import nl.esi.comma.expressions.expression.ExpressionConstantBool;
@@ -103,7 +104,9 @@ public class AssertionsHelper {
 			String map = expression(e.getRecord(), variablePrefix);
 			return String.format("%s['%s']", map, e.getField().getName());
 		} else if (expression instanceof ExpressionVariable v) {
-			return String.format("['%s']", variablePrefix.apply(v.getVariable().getName()));
+	        EObject vari = v.getVariable().eContainer();
+	        if (vari instanceof GenericScriptBlock) return variablePrefix.apply("");
+	        else return String.format("['%s']", variablePrefix.apply(v.getVariable().getName()));
 		} else if (expression instanceof ExpressionVector e) {
 			return String.format("[%s]", e.getElements().stream().map(ee -> expression (ee, variablePrefix)).collect(Collectors.joining(", ")));
 		} else if (expression instanceof ExpressionMapRW) {


### PR DESCRIPTION
This change guarantees that script-calls and assertion items will be labeled with a unique identifier.
Their uniqueness comes from the concatenation of the name given to its respective assertion-step name.

Outputs consumed by script-call and assertion items are also named accordingly.

```
matlab_calls=[
{
    "id":"myScript__AT__FriesClient_CheckReceipt_default_0", 
    "script_path":"a/b/script.sh",
    "parameters":[
        {
            "type": "OUTPUT",
            "value":"log.out"
        },
        {
            "type": "VALUE_REF",
            "value": "['step_output']['FriesClient_AwaitDelivery_default_0']['table']['clientOrder']['fries']['size']"
        }
    ]
}
{
    "id":"myScript__AT__FriesClient_CheckReceipt_default_1", 
    "script_path":"a/b/script.sh",
    "parameters":[
        {
            "type": "OUTPUT",
            "value":"log.out"
        },
        {
            "type": "VALUE_REF",
            "value": "['step_output']['FriesClient_AwaitDelivery_default_1']['table']['clientOrder']['fries']['size']"
        }
    ]
}
]

assertions = [
{
    "id":"correct_amount__AT__FriesClient_CheckReceipt_default_0", "type":"Value",
    "input":{
        "output":"['step_output']['FriesClient_AwaitDelivery_default_0']['table']['receipt']['amount']",
        "reference":5.0,
        "margin":{"type":"Absolute", "value":0.5}
    }
},
{
    "id":"correct_fries__AT__FriesClient_CheckReceipt_default_0", "type":"Value",
    "input":{
        "output":"['matlab_script']['myScript__AT__FriesClient_CheckReceipt_default_0']['myScript']['deviation']",
        "reference":1.54321,
        "margin":{"type":"Absolute", "value":0.01}
    }
}
{
    "id":"correct_amount__AT__FriesClient_CheckReceipt_default_1", "type":"Value",
    "input":{
        "output":"['step_output']['FriesClient_AwaitDelivery_default_1']['table']['receipt']['amount']",
        "reference":5.0,
        "margin":{"type":"Absolute", "value":0.5}
    }
}
]

```