### PR TITLE
adding ref.kvp and vfd.xml generators to FAST gen workflow

### DIFF
--- a/bundles/nl.esi.comma.project.standard/src/nl/esi/comma/project/standard/generator/StandardProjectGenerator.xtend
+++ b/bundles/nl.esi.comma.project.standard/src/nl/esi/comma/project/standard/generator/StandardProjectGenerator.xtend
@@ -32,6 +32,7 @@ import org.eclipse.xtext.generator.IGeneratorContext
 
 import static extension nl.esi.comma.types.utilities.EcoreUtil3.*
 import static extension nl.esi.comma.types.utilities.FileSystemAccessUtil.*
+import java.util.HashMap
 
 /**
  * Generates code from your model files on save.
@@ -103,7 +104,8 @@ class StandardProjectGenerator extends AbstractGenerator {
 
             // Generate concrete tspec
             val conTspecFsa = fsa.createFolderAccess('tspec_concrete')
-            (new FromAbstractToConcrete()).doGenerate(absTspecRes, conTspecFsa, ctx)
+            val fromAbstractToConcreteGen = new FromAbstractToConcrete(createPropertiesMap())
+            fromAbstractToConcreteGen.doGenerate(absTspecRes, conTspecFsa, ctx)
 
             val conTspecRes = conTspecFsa.loadResource(absTspecFileName, rst)
             MergeConcreteDataAssigments.transform(conTspecRes)
@@ -113,8 +115,15 @@ class StandardProjectGenerator extends AbstractGenerator {
             if (task.target == OfflineGenerationTarget.FAST) {
                 // Generate FAST testcases
                 val fastFsa = fsa.createFolderAccess('FAST')
+                fromAbstractToConcreteGen.doGenerateFAST(absTspecRes, fastFsa, ctx)
                 (new FromConcreteToFast()).doGenerate(conTspecRes, fastFsa, ctx)
             }
         }
     }
+
+    def createPropertiesMap() {
+        var properties = new HashMap<String, String>()
+        return properties
+    }
+
 }

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/JsonHelper.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/JsonHelper.xtend
@@ -65,12 +65,13 @@ class JsonHelper {
     def static String jsonElement(JsonMember elem)  '''"«elem.key»" : «jsonElement(elem.value)»'''
     def static String toXMLElement(TSJsonMember elem)  
         '''
-        «IF (isBasicType(elem.value) && elem.value != null)  »
-        <«elem.key»>«toXMLElement(elem.value)»</«elem.key»>
+        «val elemKey = elem.key»
+        «IF (isBasicType(elem.value) && elem.value !== null)  »
+        <«elemKey»>«toXMLElement(elem.value)»</«elemKey»>
         «ELSE»
-        <«elem.key»>
+        <«elemKey»>
             «toXMLElement(elem.value)»
-        </«elem.key»>
+        </«elemKey»>
         «ENDIF»
         '''
 

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/VFDXMLGenerator.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/VFDXMLGenerator.xtend
@@ -16,6 +16,7 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.ArrayList
 import java.util.HashMap
+import java.util.Map
 import java.util.List
 import java.util.TreeSet
 import java.util.stream.Collectors
@@ -36,16 +37,26 @@ class VFDXMLGenerator {
     String loc=''
     String title=''
 
-    new(){ }
+    new(){
+        this(new HashMap<String,String>())
+    }
 
     new(String ns, String xsi, String loc, String title){
-        this()
-        this.ns = ns
+        this.ns=ns
         this.xsi=xsi
         this.loc=loc
         this.title=title
     }
-    
+
+    new(Map<String, String> map) {
+        this(
+            map.getOrDefault("ns",""),
+            map.getOrDefault("xsi",""),
+            map.getOrDefault("loc",""),
+            map.getOrDefault("title","")
+        )
+    }
+
     def generateXMLFromSUTVars(AbstractTestDefinition atd) 
     {
         var now = LocalDateTime.now();


### PR DESCRIPTION
As noticed by @raulmonti FAST generator was not delivering the ref.kvp and vfd.xml files in the right folder (aka FAST).

I added a second call to the ```FromAbstractToConcrete``` object so that a subset of its code generation is done.
Especifically, I first only create the data.kvp, reference.kvp and vfd.xml files.
Next,  with the ```FromConcreteToFast``` object, I overwrite the data.kvp with the FAST version, leaving the ref.kvp and vfd.xml as originally created by the ```FromAbstractToConcrete``` object.