### PR TITLE
printing enum value instead of string literal label

### DIFF
--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/AssertionsHelper.java
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/AssertionsHelper.java
@@ -31,6 +31,8 @@ import nl.esi.comma.expressions.expression.ExpressionPlus;
 import nl.esi.comma.expressions.expression.ExpressionRecordAccess;
 import nl.esi.comma.expressions.expression.ExpressionVariable;
 import nl.esi.comma.expressions.expression.ExpressionVector;
+import nl.esi.comma.types.types.EnumElement;
+import nl.esi.comma.types.types.EnumTypeDecl;
 
 /**
  *
@@ -96,7 +98,12 @@ public class AssertionsHelper {
 		} else if (expression instanceof ExpressionConstantReal e) {
 			return Double.toString(e.getValue());
 		} else if (expression instanceof ExpressionEnumLiteral e) {
-			return Integer.toString(e.getLiteral().getValue().getValue());
+			EnumElement e_lite = e.getLiteral();
+			if (e.getLiteral().getValue() == null) {
+				EnumTypeDecl e_type = e.getType();
+		        return Integer.toString(e_type.getLiterals().indexOf(e_lite));
+	        }
+			return Integer.toString(e_lite.getValue().getValue());
 		} else if (expression instanceof ExpressionConstantBool e) {
 			return e.isValue() ? "True" : "False";
 		} else if (expression instanceof ExpressionMinus e) {

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/AssertionsHelper.java
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/AssertionsHelper.java
@@ -24,6 +24,7 @@ import nl.esi.comma.expressions.expression.ExpressionConstantBool;
 import nl.esi.comma.expressions.expression.ExpressionConstantInt;
 import nl.esi.comma.expressions.expression.ExpressionConstantReal;
 import nl.esi.comma.expressions.expression.ExpressionConstantString;
+import nl.esi.comma.expressions.expression.ExpressionEnumLiteral;
 import nl.esi.comma.expressions.expression.ExpressionMapRW;
 import nl.esi.comma.expressions.expression.ExpressionMinus;
 import nl.esi.comma.expressions.expression.ExpressionPlus;
@@ -94,6 +95,8 @@ public class AssertionsHelper {
 			return String.format("'%s'", pexpr.getValue());
 		} else if (expression instanceof ExpressionConstantReal e) {
 			return Double.toString(e.getValue());
+		} else if (expression instanceof ExpressionEnumLiteral e) {
+			return Integer.toString(e.getLiteral().getValue().getValue());
 		} else if (expression instanceof ExpressionConstantBool e) {
 			return e.isValue() ? "True" : "False";
 		} else if (expression instanceof ExpressionMinus e) {

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/AssertionsHelper.java
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/AssertionsHelper.java
@@ -99,11 +99,11 @@ public class AssertionsHelper {
 			return Double.toString(e.getValue());
 		} else if (expression instanceof ExpressionEnumLiteral e) {
 			EnumElement e_lite = e.getLiteral();
-			if (e.getLiteral().getValue() == null) {
-				EnumTypeDecl e_type = e.getType();
-		        return Integer.toString(e_type.getLiterals().indexOf(e_lite));
+			if (e.getLiteral().getValue() != null) {
+				return Integer.toString(e_lite.getValue().getValue());
 	        }
-			return Integer.toString(e_lite.getValue().getValue());
+			EnumTypeDecl e_type = e.getType();
+	        return Integer.toString(e_type.getLiterals().indexOf(e_lite));
 		} else if (expression instanceof ExpressionConstantBool e) {
 			return e.isValue() ? "True" : "False";
 		} else if (expression instanceof ExpressionMinus e) {

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/ExpressionsParser.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/ExpressionsParser.xtend
@@ -86,10 +86,10 @@ class ExpressionsParser {
 	
 	def static dispatch CharSequence generateExpression(ExpressionEnumLiteral expr, CharSequence ref)
 	{
-	    if (expr.literal.value === null) {
-	        return '''«expr.type.literals.indexOf(expr.literal)»'''
+	    if (expr.literal.value !== null) {
+	        return '''«expr.literal.value.value»'''
         }
-        return '''«expr.literal.value.value»''' 
+        return  '''«expr.type.literals.indexOf(expr.literal)»'''
 	}
 
 	// modify string to remove quotes for prefix: "platform:" && "setup.suts" [FAST Specific]

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/ExpressionsParser.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/ExpressionsParser.xtend
@@ -85,7 +85,7 @@ class ExpressionsParser {
 	'''«expr.variable.name»'''
 	
 	def static dispatch CharSequence generateExpression(ExpressionEnumLiteral expr, CharSequence ref)      
-	'''«expr.type.name».«expr.literal.name»''' 
+	'''«expr.literal.value.value»''' 
 
 	// modify string to remove quotes for prefix: "platform:" && "setup.suts" [FAST Specific]
 	def static dispatch CharSequence generateExpression(ExpressionConstantString expr, CharSequence ref)      

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/ExpressionsParser.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/ExpressionsParser.xtend
@@ -84,8 +84,13 @@ class ExpressionsParser {
 	//'''«IF JavaGeneratorUtilities::isStateMachineVariable(expr.variable)»«ref»«expr.variable.name»«ELSE»«expr.variable.name»«ENDIF»'''
 	'''«expr.variable.name»'''
 	
-	def static dispatch CharSequence generateExpression(ExpressionEnumLiteral expr, CharSequence ref)      
-	'''«expr.literal.value.value»''' 
+	def static dispatch CharSequence generateExpression(ExpressionEnumLiteral expr, CharSequence ref)
+	{
+	    if (expr.literal.value === null) {
+	        return '''«expr.type.literals.indexOf(expr.literal)»'''
+        }
+        return '''«expr.literal.value.value»''' 
+	}
 
 	// modify string to remove quotes for prefix: "platform:" && "setup.suts" [FAST Specific]
 	def static dispatch CharSequence generateExpression(ExpressionConstantString expr, CharSequence ref)      


### PR DESCRIPTION
.json and vfd.xml files are now showing enumeration items as their integer values, instead of their string literal format
