### PR TITLE
120 handle nested record types in concrete to fast

### DIFF
--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/ConcreteExpressionHandler.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/abstspec/generator/ConcreteExpressionHandler.xtend
@@ -41,7 +41,10 @@ class ConcreteExpressionHandler {
     def private String printVariable(String name, Type type, TSJsonValue value, Set<String> suppressVars) '''
         «IF type instanceof TypeReference && type.type instanceof RecordTypeDecl»
             «FOR field : (type.type as RecordTypeDecl).fields.filter[f|value.hasMemberValue(f.name)].reject[suppressVars.contains(name + '.' + it.name)]»
-                «printVariable(name + '.' + field.name, field.type, value.getMemberValue(field.name), suppressVars)»
+                «val f_name = name + '.' + field.name»
+                «val f_type= field.type»
+                «val f_value = value.getMemberValue(field.name)»
+                «f_name» := «f_type.createValue(f_value)»
             «ENDFOR»
         «ELSE»
             «name» := «type.createValue(value)»

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/ExpressionsParser.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/ExpressionsParser.xtend
@@ -67,11 +67,15 @@ class ExpressionsParser {
 
 	def static dispatch CharSequence generateExpression(ExpressionRecord expr, CharSequence ref)
 	//'''new «expr.type.name»(«IF !generateRecExpression(expr, ref).toString.contains('''ANY''')»«generateRecExpression(expr, ref)»«ENDIF»)''' 
-	'''{«generateRecExpression(expr, ref)»}'''
+	'''{
+	    «generateRecExpression(expr, ref)»
+	}'''
 	
 	def static CharSequence generateRecExpression(ExpressionRecord expr, CharSequence ref)
 	//'''«FOR f : expr.fields SEPARATOR ", "»«IF generateExpression(f, ref).toString.contains('''ANY''')»«JavaGeneratorUtilities::generateJavaTypeInitializer(f.recordField.type.type)»«ELSE»«generateExpression(f, ref)»«ENDIF»«ENDFOR»'''
-	'''«FOR f : expr.fields SEPARATOR ", "»«generateExpression(f, ref)»«ENDFOR»'''
+	'''«FOR f : expr.fields SEPARATOR ", "»
+	   «generateExpression(f, ref)»
+	«ENDFOR»'''
 
 	def static dispatch CharSequence generateExpression(Field expr, CharSequence ref)
 	'''"«expr.recordField.name»" : «generateExpression(expr.exp, ref)»'''


### PR DESCRIPTION
For printing out nested record types, I removed the recursive printing of field names in the concrete t-spec generator.
Now I iterate over fields and print them one by one.