### PR TITLE
Dropping json prefix to shorten filename, enabling windows to compress all files

### DIFF
--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/to/fast/FromConcreteToFast.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/to/fast/FromConcreteToFast.xtend
@@ -194,7 +194,7 @@ class FromConcreteToFast extends AbstractGenerator {
         // update step file names based on checking if additional data was specified. 
         for(step : listStepInstances) {
             if(!step.parameters.isEmpty) {
-                step.inputFile = step.inputFile.replaceAll(".json", "_" + step.id + ".json")
+                step.inputFile = step.inputFile.replaceFirst("[^/]+\\.json$", step.id + ".json")
             }
         }
         


### PR DESCRIPTION
This bugfix should shorten json filename (likely to something below 260 characters) so windows is able to compress these files.