### PR TITLE
[#175] Alternative implementation of causal graph language

### DIFF
--- a/bundles/nl.esi.comma.causalgraph.ide/src/nl/esi/comma/causalgraph/ide/contentassist/CausalGraphIdeProposalProvider.xtend
+++ b/bundles/nl.esi.comma.causalgraph.ide/src/nl/esi/comma/causalgraph/ide/contentassist/CausalGraphIdeProposalProvider.xtend
@@ -15,10 +15,40 @@
  */
 package nl.esi.comma.causalgraph.ide.contentassist
 
+import com.google.inject.Inject
+import nl.esi.comma.causalgraph.services.CausalGraphGrammarAccess
+import org.eclipse.xtext.Assignment
+import org.eclipse.xtext.RuleCall
+import org.eclipse.xtext.ide.editor.contentassist.ContentAssistContext
+import org.eclipse.xtext.ide.editor.contentassist.ContentAssistEntry
+import org.eclipse.xtext.ide.editor.contentassist.IIdeContentProposalAcceptor
 
 /**
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#content-assist
  * on how to customize the content assistant.
  */
 class CausalGraphIdeProposalProvider extends AbstractCausalGraphIdeProposalProvider {
+    @Inject
+    @Extension
+    CausalGraphGrammarAccess grammarAccess
+
+    override protected _createProposals(Assignment assignment, ContentAssistContext context,
+        IIdeContentProposalAcceptor acceptor) {
+        super._createProposals(assignment, context, acceptor)
+
+        val terminal = assignment.terminal
+        if (terminal instanceof RuleCall) {
+            if (terminal.rule == BODYRule) {
+                val proposal = proposalCreator.createProposal('«»', context, [ entry |
+                    entry.kind = ContentAssistEntry.KIND_SNIPPET
+                    entry.label = '«»'
+                    entry.description = 'Code snippet'
+                    entry.documentation = 'Code snippet'
+                ])
+                if (proposal !== null) {
+                    acceptor.accept(proposal, TEMPLATE_DEFAULT_PRIORITY);
+                }
+            }
+        }
+    }
 }

--- a/bundles/nl.esi.comma.causalgraph/src/nl/esi/comma/causalgraph/CausalGraph.xtext
+++ b/bundles/nl.esi.comma.causalgraph/src/nl/esi/comma/causalgraph/CausalGraph.xtext
@@ -15,7 +15,6 @@ grammar nl.esi.comma.causalgraph.CausalGraph with nl.esi.comma.actions.Actions
 
 generate causalGraph "http://www.esi.nl/comma/causalgraph/CausalGraph"
 
-import "http://www.esi.nl/comma/signature/InterfaceSignature" as sig 
 import "http://www.esi.nl/comma/types/Types" as types
 import "http://www.esi.nl/comma/expressions/Expression" as expr
 
@@ -41,101 +40,77 @@ enum StepType:
 
 CausalGraph:
     imports += Import*
-    scenarioIDDecl += ScenarioIDDecl*
-    'graph' name=ID '{'
-        'graph-type' graphType = GraphType
-        ('target-language-imports' imp = STRING)?
-        ('variables' vars+=(Variable|VarDecl)+)?
-        ('function-signatures' func+=FunctionCallDecl+)?
+    requirements += RequirementDecl*
+    scenarios += ScenarioDecl*
+    'graph' name=ID
+        'type' ':' graphType = GraphType
+        ('language' ':' language = STRING)?
+        ('header' ':' header = BODY)?
+        ('types' ':' types += TypeDecl+)?
+        ('functions' ':' func += FunctionDecl+)?
+        ('variables' ':' vars += Variable+)?
         nodes += Node+
-        cfedges += CFEdge*
-        dfedges += DFEdge*
-    '}'
+        'edges' ':' edges += Edge+
 ;
 
-ScenarioIDDecl:
-    'scenario' ':' testID = TestID
+RequirementDecl:
+    'requirement' name = ID
 ;
 
-VarDecl:
-    'var-name' ':' name = ID 'type' ':' varType = STRING
+ScenarioDecl:
+    'scenario' name = ID
 ;
 
-TestID:
-    name = ID
+@Ov@Override
+TypeDecl returns types::TypeDecl:
+	super | AliasTypeDecl
+;
+
+AliasTypeDecl:
+    'alias' name = ID alias = STRING
 ;
 
 Node:
     'node' name=ID ':'
     'step-name' ':' stepName = STRING
     'step-type' ':' stepType = StepType
-    ('step-args' ':' nodeVarDecls += NodeVarDecl+)?
-    tests += TestBody+ 
+    ('step-parameters' ':' stepParams += Variable+)?
+    tests += ScenarioStep+
 ;
 
-NodeVarDecl:
-    var = Variable (',')?
-;
-
-TestBody:
-    'scenario' name=[TestID|ID] 'step' stepNum = INT
-    ('requirement-id' ':' reqID += ID+)?
-    ('arg-assign' ':' initActions+=(AssignmentAction | RecordFieldAssignmentAction)+)?
-    'step-body' ':' stepBody += StepBody*
+ScenarioStep:
+    'scenario' name=[ScenarioDecl|ID] 'step' stepNum = INT ':'
+    ('requirements' ':' reqID += [RequirementDecl|ID]+)?
+    ('step-arguments' ':' stepArgs += (AssignmentAction | RecordFieldAssignmentAction)+)?
+    'step-body' ':' stepBody = StepBody
 ;
 
 StepBody:
-    TypedBody | StringBody
+    ActionsBody | LanguageBody
 ;
 
-StringBody:
-    id = STRING '<<' frag = STRING '>>'
+ActionsBody:
+    actions += Action+
 ;
 
-TypedBody:
-    id = STRING 'actions' act += Action+
+LanguageBody:
+    body = BODY
 ;
 
-DFEdge: 
-    'data-flow-edge' src = [Node|ID] '--' refData += Ref+ '-->' dst = [Node|ID]
-    // ('meta-data' initActions+=(AssignmentAction | RecordFieldAssignmentAction)+)?
+Edge:
+    ControlFlowEdge | DataFlowEdge
 ;
 
-Ref:
-    RefData | RefTypedData
+ControlFlowEdge:
+    src = [Node|ID] '->' dst = [Node|ID]
 ;
 
-RefData:
-    '{' tid = [TestID|ID] ':' '[' refVarList += [VarDecl|ID]+ ']' '}'
+DataFlowEdge: 
+    src = [Node|ID] '-' '{' dataRefs += DataReference (',' dataRefs += DataReference)* '}' '->' dst = [Node|ID]
 ;
 
-RefTypedData:
-    '{' '[T]' tid = [TestID|ID] ':' '[' refVarList += [expr::Variable|ID]+ ']' '}'
+DataReference:
+    scenario = [ScenarioDecl|ID] ':' (vars += [expr::Variable|ID] | '[' vars += [expr::Variable|ID] (',' vars += [expr::Variable|ID])* ']')
 ;
 
-CFEdge: 
-    'control-flow-edge' src = [Node|ID] '-->' dst = [Node|ID]
-    // ('meta-data' initActions+=(AssignmentAction | RecordFieldAssignmentAction)+)?
-;
-
-
-
-// Node:
-//    'node' name=ID ':' ('local-variables' localVars+=Variable+)? 'actions' act += Action+
-//    ('step-name' ':' stepName = STRING)?
-//    // ('step-args' ':' stepArgsInitActions+=(AssignmentAction | RecordFieldAssignmentAction)+)?
-//    ('step-args' ':' stepArgsInitActions+=KeyValuePair+)?
-//    ('step-type' ':' stepType = StepType)?
-//    ('meta-data' initActions+=(AssignmentAction | RecordFieldAssignmentAction)+)?
-// ;
-//KeyValuePair:
-//    ('param' param = STRING 'value' value = STRING)?
-//    'test-case-id' testCaseID = STRING 
-//    'requirement-id' requirementID += STRING+
-//    ('step-number' stepNum = INT)?
-//;
-
-
-//FunctionCallDecl: type = Type name = ID
-//    '(' (args += Variable (',' args += Variable)*)? ')'
-//;
+terminal BODY: '«' ( ('»»') | !('»') )* '»';

--- a/bundles/nl.esi.comma.causalgraph/src/nl/esi/comma/causalgraph/CausalGraph.xtext
+++ b/bundles/nl.esi.comma.causalgraph/src/nl/esi/comma/causalgraph/CausalGraph.xtext
@@ -40,8 +40,8 @@ enum StepType:
 
 CausalGraph:
     imports += Import*
-    requirements += RequirementDecl*
-    scenarios += ScenarioDecl*
+    requirements += RequirementDecl+
+    scenarios += ScenarioDecl+
     'graph' name=ID ':'
         'type' ':' type = GraphType
         ('language' ':' language = STRING)?
@@ -58,7 +58,8 @@ RequirementDecl:
 ;
 
 ScenarioDecl:
-    'scenario' name = ID
+    'scenario' name = ID ':'
+        'requirements' ':' requirements += [RequirementDecl|ID]+
 ;
 
 @Ov@Override
@@ -74,15 +75,15 @@ Node:
     'node' name=ID ':'
     'step-name' ':' stepName = STRING
     'step-type' ':' stepType = StepType
-    ('step-parameters' ':' stepParameters += Variable+)?
+    ('step-parameters' ':' stepParameters += Variable+
+     'step-body' ':' stepBody = StepBody)?
     tests += ScenarioStep+
 ;
 
 ScenarioStep:
     'scenario' name=[ScenarioDecl|ID] 'step' stepNumber = INT ':'
-    ('requirements' ':' requirements += [RequirementDecl|ID]+)?
-    ('step-arguments' ':' stepArguments += (AssignmentAction | RecordFieldAssignmentAction)+)?
-    'step-body' ':' stepBody = StepBody
+    ( ('step-arguments' ':' stepArguments += (AssignmentAction | RecordFieldAssignmentAction)+)
+    | ('step-body' ':' stepBody = StepBody))
 ;
 
 StepBody:

--- a/bundles/nl.esi.comma.causalgraph/src/nl/esi/comma/causalgraph/CausalGraph.xtext
+++ b/bundles/nl.esi.comma.causalgraph/src/nl/esi/comma/causalgraph/CausalGraph.xtext
@@ -42,13 +42,13 @@ CausalGraph:
     imports += Import*
     requirements += RequirementDecl*
     scenarios += ScenarioDecl*
-    'graph' name=ID
-        'type' ':' graphType = GraphType
+    'graph' name=ID ':'
+        'type' ':' type = GraphType
         ('language' ':' language = STRING)?
         ('header' ':' header = BODY)?
         ('types' ':' types += TypeDecl+)?
-        ('functions' ':' func += FunctionDecl+)?
-        ('variables' ':' vars += Variable+)?
+        ('functions' ':' functions += FunctionDecl+)?
+        ('variables' ':' variables += Variable+)?
         nodes += Node+
         'edges' ':' edges += Edge+
 ;
@@ -74,14 +74,14 @@ Node:
     'node' name=ID ':'
     'step-name' ':' stepName = STRING
     'step-type' ':' stepType = StepType
-    ('step-parameters' ':' stepParams += Variable+)?
+    ('step-parameters' ':' stepParameters += Variable+)?
     tests += ScenarioStep+
 ;
 
 ScenarioStep:
-    'scenario' name=[ScenarioDecl|ID] 'step' stepNum = INT ':'
-    ('requirements' ':' reqID += [RequirementDecl|ID]+)?
-    ('step-arguments' ':' stepArgs += (AssignmentAction | RecordFieldAssignmentAction)+)?
+    'scenario' name=[ScenarioDecl|ID] 'step' stepNumber = INT ':'
+    ('requirements' ':' requirements += [RequirementDecl|ID]+)?
+    ('step-arguments' ':' stepArguments += (AssignmentAction | RecordFieldAssignmentAction)+)?
     'step-body' ':' stepBody = StepBody
 ;
 
@@ -102,15 +102,15 @@ Edge:
 ;
 
 ControlFlowEdge:
-    src = [Node|ID] '->' dst = [Node|ID]
+    source = [Node|ID] '->' target = [Node|ID]
 ;
 
 DataFlowEdge: 
-    src = [Node|ID] '-' '{' dataRefs += DataReference (',' dataRefs += DataReference)* '}' '->' dst = [Node|ID]
+    source = [Node|ID] '-' '{' dataReferences += DataReference (',' dataReferences += DataReference)* '}' '->' target = [Node|ID]
 ;
 
 DataReference:
-    scenario = [ScenarioDecl|ID] ':' (vars += [expr::Variable|ID] | '[' vars += [expr::Variable|ID] (',' vars += [expr::Variable|ID])* ']')
+    scenario = [ScenarioDecl|ID] ':' (variables += [expr::Variable|ID] | '[' variables += [expr::Variable|ID] (',' variables += [expr::Variable|ID])* ']')
 ;
 
 terminal BODY: '«' ( ('»»') | !('»') )* '»';

--- a/bundles/nl.esi.comma.causalgraph/src/nl/esi/comma/causalgraph/CausalGraphRuntimeModule.xtend
+++ b/bundles/nl.esi.comma.causalgraph/src/nl/esi/comma/causalgraph/CausalGraphRuntimeModule.xtend
@@ -15,7 +15,11 @@
  */
 package nl.esi.comma.causalgraph
 
+import nl.esi.comma.causalgraph.conversion.CausalGraphValueConverterService
+import nl.esi.comma.causalgraph.formatting.CausalGraphFormatter
 import nl.esi.comma.types.scoping.TypesImportUriGlobalScopeProvider
+import org.eclipse.xtext.conversion.IValueConverterService
+import org.eclipse.xtext.formatting.IFormatter
 
 /**
  * Use this class to register components to be used at runtime / without the Equinox extension registry.
@@ -23,5 +27,13 @@ import nl.esi.comma.types.scoping.TypesImportUriGlobalScopeProvider
 class CausalGraphRuntimeModule extends AbstractCausalGraphRuntimeModule {
     override bindIGlobalScopeProvider() {
         return TypesImportUriGlobalScopeProvider
+    }
+
+    override Class<? extends IValueConverterService> bindIValueConverterService() {
+        return CausalGraphValueConverterService
+    }
+
+    override Class<? extends IFormatter> bindIFormatter() {
+        return CausalGraphFormatter
     }
 }

--- a/bundles/nl.esi.comma.causalgraph/src/nl/esi/comma/causalgraph/conversion/BodyValueConverter.xtend
+++ b/bundles/nl.esi.comma.causalgraph/src/nl/esi/comma/causalgraph/conversion/BodyValueConverter.xtend
@@ -1,0 +1,21 @@
+package nl.esi.comma.causalgraph.conversion
+
+import org.eclipse.xtext.conversion.IValueConverter
+import org.eclipse.xtext.conversion.ValueConverterException
+import org.eclipse.xtext.nodemodel.INode
+
+class BodyValueConverter implements IValueConverter<String> {
+    override toString(String value) throws ValueConverterException {
+        return if (value !== null) '«' + value.replace('»', '»»') + '»';
+    }
+
+    override toValue(String string, INode node) throws ValueConverterException {
+        return if (string === null) {
+            null;
+        } else if (string.length >= 2) {
+            string.substring(1, string.length - 1).replace('»»', '»')
+        } else {
+            ''
+        }
+    }
+}

--- a/bundles/nl.esi.comma.causalgraph/src/nl/esi/comma/causalgraph/conversion/CausalGraphValueConverterService.xtend
+++ b/bundles/nl.esi.comma.causalgraph/src/nl/esi/comma/causalgraph/conversion/CausalGraphValueConverterService.xtend
@@ -1,0 +1,12 @@
+package nl.esi.comma.causalgraph.conversion
+
+import org.eclipse.xtext.common.services.DefaultTerminalConverters
+import org.eclipse.xtext.conversion.IValueConverter
+import org.eclipse.xtext.conversion.ValueConverter
+
+class CausalGraphValueConverterService extends DefaultTerminalConverters {
+    @ValueConverter(rule = "BODY")
+    def IValueConverter<String> getBodyConverter() {
+        return new BodyValueConverter();
+    }
+}

--- a/bundles/nl.esi.comma.causalgraph/src/nl/esi/comma/causalgraph/formatting/CausalGraphFormatter.xtend
+++ b/bundles/nl.esi.comma.causalgraph/src/nl/esi/comma/causalgraph/formatting/CausalGraphFormatter.xtend
@@ -1,0 +1,61 @@
+package nl.esi.comma.causalgraph.formatting
+
+import com.google.inject.Inject
+import nl.esi.comma.causalgraph.services.CausalGraphGrammarAccess
+import org.eclipse.xtext.formatting.impl.AbstractDeclarativeFormatter
+import org.eclipse.xtext.formatting.impl.FormattingConfig
+
+class CausalGraphFormatter extends AbstractDeclarativeFormatter {
+    @Inject
+    @Extension
+    var CausalGraphGrammarAccess grammarAccess;
+
+    override protected configureFormatting(FormattingConfig it) {
+        autoLinewrap = 120
+
+        // Comments
+        setLinewrap(0, 1, 2).before(SL_COMMENTRule)
+        setLinewrap(0, 1, 2).before(ML_COMMENTRule)
+        setLinewrap(0, 1, 1).after(ML_COMMENTRule)
+
+        for (pair : findKeywordPairs("{", "}")) {
+            setNoSpace().before(pair.first);
+            setNoSpace().after(pair.first);
+            setNoSpace().before(pair.second);
+        }
+        for (pair : findKeywordPairs("(", ")")) {
+            setNoSpace().before(pair.first);
+            setNoSpace().after(pair.first);
+            setNoSpace().before(pair.second);
+        }
+        for (pair : findKeywordPairs("[", "]")) {
+            setNoSpace().before(pair.first);
+            setNoSpace().after(pair.first);
+            setNoSpace().before(pair.second);
+        }
+        for (keyword : findKeywords(",",":")) {
+            setNoSpace().before(keyword);
+        }
+
+        // TODO: Grammar formatting
+        setLinewrap(1,1,2).after(requirementDeclRule)
+        setLinewrap(1,1,2).after(scenarioDeclRule)
+
+        setLinewrap(1,1,2).after(causalGraphAccess.nameAssignment_4)
+        setLinewrap(1,1,2).after(causalGraphAccess.typeAssignment_8)
+        setLinewrap(1,1,2).after(causalGraphAccess.languageAssignment_9_2)
+        setLinewrap(1,1,2).after(causalGraphAccess.headerAssignment_10_2)
+
+        setLinewrap(1,1,2).before(causalGraphAccess.typesAssignment_11_2)
+        setLinewrap(1,1,2).after(typeDeclRule)
+        setIndentation(causalGraphAccess.typesKeyword_11_0, causalGraphAccess.functionsKeyword_12_0)
+        setLinewrap(1,1,2).after(functionDeclRule)
+        setIndentation(causalGraphAccess.functionsKeyword_12_0, causalGraphAccess.variablesKeyword_13_0)
+        setLinewrap(1,1,2).after(variableRule)
+        setIndentation(causalGraphAccess.variablesKeyword_13_0, nodeAccess.nodeKeyword_0)
+        setLinewrap(1,1,2).after(nodeRule)
+        setLinewrap(1,1,2).after(nodeAccess.nameAssignment_1)
+        setIndentation(nodeAccess.nameAssignment_1, nodeAccess.nodeKeyword_0)
+        setLinewrap(1,1,2).after(nodeRule)
+   }
+}

--- a/bundles/nl.esi.comma.causalgraph/src/nl/esi/comma/causalgraph/generator/CSharpHelper.java
+++ b/bundles/nl.esi.comma.causalgraph/src/nl/esi/comma/causalgraph/generator/CSharpHelper.java
@@ -12,14 +12,11 @@
  */
 package nl.esi.comma.causalgraph.generator;
 
-import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import nl.esi.comma.actions.actions.Action;
 import nl.esi.comma.actions.actions.AssignmentAction;
-import nl.esi.comma.actions.actions.CommandReply;
-import nl.esi.comma.actions.actions.EventCall;
 import nl.esi.comma.actions.actions.ForAction;
 import nl.esi.comma.actions.actions.FunctionCall;
 import nl.esi.comma.actions.actions.IfAction;
@@ -63,9 +60,7 @@ import nl.esi.comma.expressions.expression.ExpressionSubtraction;
 import nl.esi.comma.expressions.expression.ExpressionVariable;
 import nl.esi.comma.expressions.expression.ExpressionVector;
 import nl.esi.comma.expressions.expression.QUANTIFIER;
-import nl.esi.comma.expressions.expression.Variable;
 import nl.esi.comma.expressions.generator.ExpressionsCommaGenerator;
-import nl.esi.comma.signature.interfaceSignature.DIRECTION;
 import nl.esi.comma.types.types.EnumTypeDecl;
 import nl.esi.comma.types.types.MapTypeDecl;
 import nl.esi.comma.types.types.RecordTypeDecl;
@@ -189,7 +184,7 @@ class CSharpHelper {
 				if(!str.isEmpty()) str += ", ";
 				str += expression(arg, variablePrefix);
 			}
-			String fnName = e.getFunctionName().getName();
+			String fnName = e.getFunction().getName();
 			fnName = fnName.replaceAll("_DOT_", ".");
 			fnName = fnName.replaceAll("_PTR_", ".");
 			fnName = fnName.replaceAll("_SCOPE_", "::");

--- a/bundles/nl.esi.comma.expressions/src/nl/esi/comma/expressions/Expression.xtext
+++ b/bundles/nl.esi.comma.expressions/src/nl/esi/comma/expressions/Expression.xtext
@@ -19,13 +19,14 @@ import "http://www.esi.nl/comma/types/Types" as types
 import "http://www.esi.nl/comma/signature/InterfaceSignature" as signature
 
 Variable: type = Type name= ID ;
-FunctionCallDecl: type = Type name = ID
-    '(' (args += Variable (',' args += Variable)*)? ')'
+
+FunctionDecl:
+    returnType = Type name = ID '(' (params += Variable (',' params += Variable)*)? ')'
 ;
 
 @Override
 NamedElement returns types::NamedElement:
-	super::NamedElement | Variable | FunctionCallDecl
+	super::NamedElement | Variable | FunctionDecl
 ;
 
 Expression: ExpressionLevel1;
@@ -117,7 +118,7 @@ ExpressionLevel9 returns Expression:
 ;
 
 ExpressionFnCall: 
-    'call' functionName = [FunctionCallDecl|ID] '(' (args += Expression (',' args += Expression)*)? ')'
+    'call' function = [FunctionDecl|ID] '(' (args += Expression (',' args += Expression)*)? ')'
 ;
 
 ExpressionBracket:

--- a/bundles/nl.esi.comma.expressions/src/nl/esi/comma/expressions/generator/ExpressionsCommaGenerator.xtend
+++ b/bundles/nl.esi.comma.expressions/src/nl/esi/comma/expressions/generator/ExpressionsCommaGenerator.xtend
@@ -140,7 +140,7 @@ class ExpressionsCommaGenerator extends TypesCommaGenerator {
             if(!str.isEmpty()) str += ", ";
             str += exprToComMASyntax(arg);
         }
-        var fnName = e.getFunctionName().getName();
+        var fnName = e.getFunction().getName();
         fnName = fnName.replaceAll("_DOT_", ".");
         fnName = fnName.replaceAll("_PTR_", ".");
         fnName = fnName.replaceAll("_SCOPE_", "::");


### PR DESCRIPTION
This is an alternative implementation of the causal graph language, which i.m.h.o. is a bit cleaner and more consistent. Attached are two examples, 1) a graph with C++ code and 2) a graph with actions. I still have to fix the parsing of the bodies though, as the guillemets are currently still part of the value.

[examples.zip](https://github.com/user-attachments/files/21488467/examples.zip)
