### PR TITLE
Add validation for multi Run step

### DIFF
--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/validation/ProductValidator.xtend
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/validation/ProductValidator.xtend
@@ -35,6 +35,7 @@ import nl.esi.comma.types.types.TypesPackage
 import org.eclipse.emf.common.util.URI
 import org.eclipse.xtext.EcoreUtil2
 import org.eclipse.xtext.validation.Check
+import nl.asml.matala.product.product.ActionType
 
 /**
  * This class contains custom validation rules. 
@@ -201,7 +202,7 @@ class ProductValidator extends AbstractProductValidator {
      */
      @Check
     def checkMultiRunSteps(Block block) {
-        val runUpdates = block.functions.flatMap[updates].filter[actionType.getName == "RUN"]
+        val runUpdates = block.functions.flatMap[updates].filter[actionType == ActionType::RUN]
 
         val groupedByStepType = runUpdates.groupBy[stepType]
 
@@ -209,7 +210,7 @@ class ProductValidator extends AbstractProductValidator {
             val mostCommon = groupedByStepType.entrySet.maxBy[value.size].key
             runUpdates.filter[stepType != mostCommon].forEach [ update |
                 error(
-                    "All stepTypes must be the same for actionType RUN (expected: " + mostCommon + ")",
+                    "All step-types must be the same for action-type RUN (expected: " + mostCommon + ")",
                     update,
                     ProductPackage.Literals.UPDATE__STEP_TYPE
                 )

--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/validation/ProductValidator.xtend
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/validation/ProductValidator.xtend
@@ -219,15 +219,6 @@ class ProductValidator extends AbstractProductValidator {
     }
  
     /**
-     * Name of global model should not have underscores */
-    @Check
-    def checkBlockID(Block block) {
-        if (block.name.contains("_")) {
-            error("ID should not have underscores ", ProductPackage.Literals.BLOCK__NAME)
-        }
-    }
-
-    /**
      * Run step must always have step type.
      */
     @Check

--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/validation/ProductValidator.xtend
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/validation/ProductValidator.xtend
@@ -195,6 +195,29 @@ class ProductValidator extends AbstractProductValidator {
         expr.eContents.filter(Expression).forEach[preventIlligalVariableAccess(variables, direction)]
     }
 
+
+    /**
+     * A system block may have many RUN steps but they all must be of the same step-type
+     */
+     @Check
+    def checkMultiRunSteps(Block block) {
+        val runUpdates = block.functions.flatMap[updates].filter[actionType.getName == "RUN"]
+
+        val groupedByStepType = runUpdates.groupBy[stepType]
+
+        if (groupedByStepType.keySet.size > 1) {
+            val mostCommon = groupedByStepType.entrySet.maxBy[value.size].key
+            runUpdates.filter[stepType != mostCommon].forEach [ update |
+                error(
+                    "All stepTypes must be the same for actionType RUN (expected: " + mostCommon + ")",
+                    update,
+                    ProductPackage.Literals.UPDATE__STEP_TYPE
+                )
+            ]
+        }
+
+    }
+ 
 /* STRANGE BUG: Output Vars are Empty. Appears in Input Vars. 
  * Not appearing as problem during product generation!
  */


### PR DESCRIPTION
A system block may have many RUN steps but they all must be of the same step-type