### PR TITLE
Add validation on guards so that the types of the RHS and LHS of the

### DIFF
--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/validation/ProductValidator.xtend
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/validation/ProductValidator.xtend
@@ -195,19 +195,6 @@ class ProductValidator extends AbstractProductValidator {
         expr.eContents.filter(Expression).forEach[preventIlligalVariableAccess(variables, direction)]
     }
 
-    /**
-     * Prevent type mismatch in guards
-     */
-     
-     @Check
-     def checkGaurdsTypeMisMatch(Function function){
-         for (update : function.updates) {
-            if (update.guard !== null) {
-                 update.guard.checkTypingExpression
-            }
-        }
-     }
-
 /* STRANGE BUG: Output Vars are Empty. Appears in Input Vars. 
  * Not appearing as problem during product generation!
  */

--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/validation/ProductValidator.xtend
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/validation/ProductValidator.xtend
@@ -195,6 +195,19 @@ class ProductValidator extends AbstractProductValidator {
         expr.eContents.filter(Expression).forEach[preventIlligalVariableAccess(variables, direction)]
     }
 
+    /**
+     * Prevent type mismatch in guards
+     */
+     
+     @Check
+     def checkGaurdsTypeMisMatch(Function function){
+         for (update : function.updates) {
+            if (update.guard !== null) {
+                 update.guard.checkTypingExpression
+            }
+        }
+     }
+
 /* STRANGE BUG: Output Vars are Empty. Appears in Input Vars. 
  * Not appearing as problem during product generation!
  */

--- a/bundles/nl.esi.comma.expressions/src/nl/esi/comma/expressions/validation/ExpressionValidator.xtend
+++ b/bundles/nl.esi.comma.expressions/src/nl/esi/comma/expressions/validation/ExpressionValidator.xtend
@@ -206,6 +206,7 @@ class ExpressionValidator extends AbstractExpressionValidator {
 		    ExpressionEqual:{
 		        val leftType = e.left.typeOf
 		        val rightType = e.right.typeOf
+		        if(leftType === null || rightType === null) {return}
                 if(!leftType.synonym(rightType)){
                     error("Type mismatch: actual type does not match the expected type", ExpressionPackage.Literals.EXPRESSION_BINARY__LEFT)
                 }

--- a/bundles/nl.esi.comma.expressions/src/nl/esi/comma/expressions/validation/ExpressionValidator.xtend
+++ b/bundles/nl.esi.comma.expressions/src/nl/esi/comma/expressions/validation/ExpressionValidator.xtend
@@ -203,6 +203,13 @@ class ExpressionValidator extends AbstractExpressionValidator {
 	@Check
 	def checkTypingExpression(Expression e){
 		switch(e){
+		    ExpressionEqual:{
+		        val leftType = e.left.typeOf
+		        val rightType = e.right.typeOf
+                if(leftType != rightType){
+                    error("Type mismatch: actual type does not match the expected type", ExpressionPackage.Literals.EXPRESSION_BINARY__LEFT)
+                }
+		    }
 			ExpressionAnd |
 			ExpressionOr : {
 				val leftType = e.left.typeOf

--- a/bundles/nl.esi.comma.expressions/src/nl/esi/comma/expressions/validation/ExpressionValidator.xtend
+++ b/bundles/nl.esi.comma.expressions/src/nl/esi/comma/expressions/validation/ExpressionValidator.xtend
@@ -206,7 +206,7 @@ class ExpressionValidator extends AbstractExpressionValidator {
 		    ExpressionEqual:{
 		        val leftType = e.left.typeOf
 		        val rightType = e.right.typeOf
-                if(leftType != rightType){
+                if(!leftType.synonym(rightType)){
                     error("Type mismatch: actual type does not match the expected type", ExpressionPackage.Literals.EXPRESSION_BINARY__LEFT)
                 }
 		    }


### PR DESCRIPTION
Guards validations: Currently any record to record comparison type-passes, no matter the type of the record. You can actually compare anything you want, for instance a record against an integer. Prevent this by checking LHS and RHS type.


Note: To add the validation, I change Expression Validation file. We had already a function for validation on expression type but was not complete. 