### PR TITLE
Hotfix to be removed once assertion actions have a type

### DIFF
--- a/bundles/nl.asml.matala.bpmn4s/src/nl/asml/matala/bpmn4s/bpmn4s/Bpmn4sCompiler.java
+++ b/bundles/nl.asml.matala.bpmn4s/src/nl/asml/matala/bpmn4s/bpmn4s/Bpmn4sCompiler.java
@@ -492,7 +492,9 @@ public class Bpmn4sCompiler{
 					if (model.isComposeTask(node.getId())) {
 						stepConf = String.format(" step-type \"%s\" action-type COMPOSE", node.getStepType());
 					} else if(model.isAssertTask(node.getId())) {
-						stepConf = String.format(" step-type \"%s\" action-type ASSERT", node.getStepType());
+						//stepConf = String.format(" step-type \"%s\" action-type ASSERT", node.getStepType());
+						// TODO: hotfix to be removed once actions of type assertion are enforced to have a type 
+						stepConf = String.format(" step-type \"%s\" action-type ASSERT", sanitize(repr(node)));
 					} else if(model.isRunTask(node.getId())) {
 						stepConf = String.format(" step-type \"%s\" action-type RUN", node.getStepType());
 					}


### PR DESCRIPTION
Once @Yuri-Blankenstein-TNO enforces in the UI that actions of type ```ASSERT``` are always defined, this change should be reverted.