### PR TITLE
[#199] Support 'null' keyword in expression language

### DIFF
--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/generator/SnakesHelper.java
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/generator/SnakesHelper.java
@@ -50,6 +50,7 @@ import nl.esi.comma.expressions.expression.ExpressionModulo;
 import nl.esi.comma.expressions.expression.ExpressionMultiply;
 import nl.esi.comma.expressions.expression.ExpressionNEqual;
 import nl.esi.comma.expressions.expression.ExpressionNot;
+import nl.esi.comma.expressions.expression.ExpressionNullLiteral;
 import nl.esi.comma.expressions.expression.ExpressionOr;
 import nl.esi.comma.expressions.expression.ExpressionPlus;
 import nl.esi.comma.expressions.expression.ExpressionPower;
@@ -181,6 +182,8 @@ class SnakesHelper {
 		} else if (expression instanceof ExpressionEnumLiteral) {
 			ExpressionEnumLiteral e = (ExpressionEnumLiteral) expression;
 			return String.format("\"%s::%s\"", e.getType().getName(), e.getLiteral().getName());
+		} else if (expression instanceof ExpressionNullLiteral) {
+			return "None";
 		} else if (expression instanceof ExpressionVector) {
 			ExpressionVector e = (ExpressionVector) expression;
 			return String.format("[%s]", e.getElements().stream().map(ee -> expression (ee, variablePrefix)).collect(Collectors.joining(", ")));

--- a/bundles/nl.esi.comma.abstracttestspecification/src/nl/esi/comma/abstracttestspecification/AbstractTestspecification.xtext
+++ b/bundles/nl.esi.comma.abstracttestspecification/src/nl/esi/comma/abstracttestspecification/AbstractTestspecification.xtext
@@ -124,5 +124,6 @@ JsonExpression returns assertthat::JsonExpression:
 AbstractTestExpressionConstants returns expr::Expression:
     ExpressionConstantInt  | ExpressionConstantReal | ExpressionConstantBool | ExpressionConstantString // basic types
     | ExpressionMinus | ExpressionPlus // signed numbers
+    | ExpressionNullLiteral // null value
 ;
 

--- a/bundles/nl.esi.comma.abstracttestspecification/src/nl/esi/comma/abstracttestspecification/generator/to/concrete/AssertionsHelper.java
+++ b/bundles/nl.esi.comma.abstracttestspecification/src/nl/esi/comma/abstracttestspecification/generator/to/concrete/AssertionsHelper.java
@@ -27,6 +27,7 @@ import nl.esi.comma.expressions.expression.ExpressionConstantString;
 import nl.esi.comma.expressions.expression.ExpressionEnumLiteral;
 import nl.esi.comma.expressions.expression.ExpressionMapRW;
 import nl.esi.comma.expressions.expression.ExpressionMinus;
+import nl.esi.comma.expressions.expression.ExpressionNullLiteral;
 //import nl.esi.comma.expressions.expression.ExpressionMinus;
 import nl.esi.comma.expressions.expression.ExpressionPlus;
 import nl.esi.comma.expressions.expression.ExpressionRecordAccess;
@@ -67,6 +68,8 @@ public class AssertionsHelper {
 	        }
 			EnumTypeDecl e_type = e.getType();
 	        return Integer.toString(e_type.getLiterals().indexOf(e_lite));
+		} else if (expression instanceof ExpressionNullLiteral) {
+			return "null";
 		} else if (expression instanceof ExpressionConstantBool e) {
 			return e.isValue() ? "True" : "False";
 		} else if (expression instanceof ExpressionMinus e) {

--- a/bundles/nl.esi.comma.abstracttestspecification/src/nl/esi/comma/abstracttestspecification/generator/to/concrete/FromAbstractToConcrete.xtend
+++ b/bundles/nl.esi.comma.abstracttestspecification/src/nl/esi/comma/abstracttestspecification/generator/to/concrete/FromAbstractToConcrete.xtend
@@ -17,7 +17,6 @@ import java.util.HashSet
 import java.util.Map
 import nl.asml.matala.product.product.Product
 import nl.esi.comma.abstracttestspecification.abstractTestspecification.AbstractTestDefinition
-import nl.esi.comma.abstracttestspecification.abstractTestspecification.AssertStep
 import nl.esi.comma.abstracttestspecification.abstractTestspecification.AssertionStep
 import nl.esi.comma.abstracttestspecification.abstractTestspecification.Binding
 import nl.esi.comma.abstracttestspecification.abstractTestspecification.ExecutableStep
@@ -163,7 +162,7 @@ class FromAbstractToConcrete extends AbstractGenerator {
             var abs_assert = step
             var cexpr_handler = new ConcreteExpressionHandler()
             return switch (grammarElement) {
-                case gaExpression.expressionLevel9Access.expressionVariableParserRuleCall_6: {
+                case gaExpression.expressionLevel9Access.expressionVariableParserRuleCall_7: {
                     val exprVar = semanticElement as ExpressionVariable
                     return cexpr_handler.prepareAssertionStepExpressions(abs_assert, exprVar)
                 }

--- a/bundles/nl.esi.comma.abstracttestspecification/src/nl/esi/comma/abstracttestspecification/generator/utils/Utils.xtend
+++ b/bundles/nl.esi.comma.abstracttestspecification/src/nl/esi/comma/abstracttestspecification/generator/utils/Utils.xtend
@@ -58,6 +58,7 @@ import org.eclipse.emf.common.util.EList
 import org.eclipse.emf.ecore.util.EcoreUtil
 
 import static extension nl.esi.comma.types.utilities.EcoreUtil3.serialize
+import nl.esi.comma.expressions.expression.ExpressionNullLiteral
 
 class Utils 
 {
@@ -168,6 +169,7 @@ class Utils
                     ExpressionConstantInt: String.valueOf(expr.value)
                     ExpressionMinus: getStringSignedValue(expr)
                     ExpressionPlus: getStringSignedValue(expr)
+                    ExpressionNullLiteral: 'null'
                     default: throw new IllegalArgumentException('Unknown Expression type ' + expr)
                 }
             }

--- a/bundles/nl.esi.comma.causalgraph/src/nl/esi/comma/causalgraph/generator/CSharpHelper.java
+++ b/bundles/nl.esi.comma.causalgraph/src/nl/esi/comma/causalgraph/generator/CSharpHelper.java
@@ -50,6 +50,7 @@ import nl.esi.comma.expressions.expression.ExpressionModulo;
 import nl.esi.comma.expressions.expression.ExpressionMultiply;
 import nl.esi.comma.expressions.expression.ExpressionNEqual;
 import nl.esi.comma.expressions.expression.ExpressionNot;
+import nl.esi.comma.expressions.expression.ExpressionNullLiteral;
 import nl.esi.comma.expressions.expression.ExpressionOr;
 import nl.esi.comma.expressions.expression.ExpressionPlus;
 import nl.esi.comma.expressions.expression.ExpressionPower;
@@ -164,6 +165,8 @@ class CSharpHelper {
 		} else if (expression instanceof ExpressionEnumLiteral) {
 			ExpressionEnumLiteral e = (ExpressionEnumLiteral) expression;
 			return String.format("\"%s:%s\"", e.getType().getName(), e.getLiteral().getName());
+		} else if (expression instanceof ExpressionNullLiteral) {
+			return "null";
 		} else if (expression instanceof ExpressionVector) {
 			ExpressionVector e = (ExpressionVector) expression;
 			return String.format("[%s]", e.getElements().stream().map(ee -> expression (ee, variablePrefix)).collect(Collectors.joining(", ")));

--- a/bundles/nl.esi.comma.expressions/src/nl/esi/comma/expressions/Expression.xtext
+++ b/bundles/nl.esi.comma.expressions/src/nl/esi/comma/expressions/Expression.xtext
@@ -107,6 +107,7 @@ ExpressionLevel9 returns Expression:
 	ExpressionConstantReal |
 	ExpressionConstantString |
 	ExpressionEnumLiteral |
+    ExpressionNullLiteral |
 	ExpressionVariable |
 	ExpressionRecord |
 	ExpressionAny |
@@ -143,6 +144,11 @@ ExpressionConstantString:
 
 ExpressionEnumLiteral: 
 	(interface = [signature::Signature|ID] '::')? type = [types::EnumTypeDecl] "::" literal = [types::EnumElement] 
+;
+
+ExpressionNullLiteral:
+    {ExpressionNullLiteral}
+    'null'
 ;
 
 ExpressionVariable: 

--- a/bundles/nl.esi.comma.expressions/src/nl/esi/comma/expressions/utilities/ProposalHelper.java
+++ b/bundles/nl.esi.comma.expressions/src/nl/esi/comma/expressions/utilities/ProposalHelper.java
@@ -44,6 +44,7 @@ import nl.esi.comma.expressions.expression.ExpressionModulo;
 import nl.esi.comma.expressions.expression.ExpressionMultiply;
 import nl.esi.comma.expressions.expression.ExpressionNEqual;
 import nl.esi.comma.expressions.expression.ExpressionNot;
+import nl.esi.comma.expressions.expression.ExpressionNullLiteral;
 import nl.esi.comma.expressions.expression.ExpressionOr;
 import nl.esi.comma.expressions.expression.ExpressionPlus;
 import nl.esi.comma.expressions.expression.ExpressionPower;
@@ -225,6 +226,8 @@ public class ProposalHelper {
 		} else if (expression instanceof ExpressionEnumLiteral) {
 			ExpressionEnumLiteral e = (ExpressionEnumLiteral) expression;
 			return String.format("\"%s:%s\"", e.getType().getName(), e.getLiteral().getName());
+		} else if (expression instanceof ExpressionNullLiteral) {
+			return "null";
 		} else if (expression instanceof ExpressionVector) {
 			ExpressionVector e = (ExpressionVector) expression;
 			return String.format("[%s]", e.getElements().stream().map(ee -> expression (ee, variablePrefix)).collect(Collectors.joining(", ")));

--- a/bundles/nl.esi.comma.expressions/src/nl/esi/comma/expressions/validation/ExpressionValidator.xtend
+++ b/bundles/nl.esi.comma.expressions/src/nl/esi/comma/expressions/validation/ExpressionValidator.xtend
@@ -28,6 +28,7 @@ import nl.esi.comma.expressions.expression.ExpressionConstantString
 import nl.esi.comma.expressions.expression.ExpressionDivision
 import nl.esi.comma.expressions.expression.ExpressionEnumLiteral
 import nl.esi.comma.expressions.expression.ExpressionEqual
+import nl.esi.comma.expressions.expression.ExpressionFnCall
 import nl.esi.comma.expressions.expression.ExpressionFunctionCall
 import nl.esi.comma.expressions.expression.ExpressionGeq
 import nl.esi.comma.expressions.expression.ExpressionGreater
@@ -42,6 +43,7 @@ import nl.esi.comma.expressions.expression.ExpressionModulo
 import nl.esi.comma.expressions.expression.ExpressionMultiply
 import nl.esi.comma.expressions.expression.ExpressionNEqual
 import nl.esi.comma.expressions.expression.ExpressionNot
+import nl.esi.comma.expressions.expression.ExpressionNullLiteral
 import nl.esi.comma.expressions.expression.ExpressionOr
 import nl.esi.comma.expressions.expression.ExpressionPackage
 import nl.esi.comma.expressions.expression.ExpressionPlus
@@ -71,8 +73,6 @@ import org.eclipse.xtext.scoping.IScopeProvider
 import org.eclipse.xtext.validation.Check
 
 import static extension nl.esi.comma.types.utilities.TypeUtilities.*
-import nl.esi.comma.expressions.expression.ExpressionFnCall
-import static nl.esi.comma.types.utilities.TypeUtilities.subTypeOf
 
 /*
  * This class mainly captures the ComMA type system for expressions. Constraints are not formulated
@@ -145,6 +145,7 @@ class ExpressionValidator extends AbstractExpressionValidator {
 			ExpressionConstantString : stringType
 			ExpressionBracket : e.sub?.typeOf
 			ExpressionEnumLiteral : e.type
+            ExpressionNullLiteral : anyType
 			ExpressionRecord : e.type
 			ExpressionRecordAccess : e.field?.type?.typeObject
 			ExpressionBulkData : bulkdataType


### PR DESCRIPTION
The `null` value is now supported by the expression language and works until the concrete test spec.
I do not know if the test specifications comply with your expectations, so please review the functionality.

@damascenodiego having `null` values in abstract/concrete test specifications will impact the tspec2FAST transformations, so please update accordingly.