### PR TITLE
filtering variables for in.data.suts using "sut_setup_" prefix

### DIFF
--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/to/fast/FromConcreteToFast.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/to/fast/FromConcreteToFast.xtend
@@ -699,12 +699,12 @@ class FromConcreteToFast extends AbstractGenerator {
     }
 
     private def boolean isInDataSuts(Action act) {
-        val IDS_NAME = 'sut_setup'
+        val IDS_NAME = 'sut_setup_'
         return switch (act) {
             RecordFieldAssignmentAction: {
                 var exp = act.fieldAccess
                 switch (exp) {
-                    ExpressionRecordAccess: exp.field.name.equals(IDS_NAME)
+                    ExpressionRecordAccess: exp.field.name.startsWith(IDS_NAME)
                     default: false
                 }
             }


### PR DESCRIPTION
As requested by @raulmonti , the SUT configuration datastores used by the ```in.data.suts``` field of ```data.kvp``` files are now identified by the prefix ```sut_setup_.*``` instead of the exact name ```sut_setup``` .