### PR TITLE
Cascading BPMN elements labels into product actions and abstract tspec steps 

### DIFF
--- a/bundles/nl.asml.matala.bpmn4s.tests/resources/expected/fries_comp/fries_comp.ps
+++ b/bundles/nl.asml.matala.bpmn4s.tests/resources/expected/fries_comp/fries_comp.ps
@@ -4,20 +4,20 @@ specification fries_comp
     system Activity_1nx4k9r
     {
         inputs
-        FriesDelivery	DataObjectReference_08usvro
+        FriesDelivery   DataObjectReference_08usvro
         
         outputs
-        FriesOrder		DataObjectReference_1kx41i3
+        FriesOrder      DataObjectReference_1kx41i3
     
         local
-        FriesDelivery	DataStoreReference_0kulgbq
-        ClientContext	Gateway_0bsgusg
-        ClientContext	Gateway_01j7v59
+        FriesDelivery   DataStoreReference_0kulgbq
+        ClientContext   Gateway_0bsgusg
+        ClientContext   Gateway_01j7v59
         
-        ClientContext	Event_022qurv
-        ClientContext	Flow_09zlhyo
-        ClientContext	Flow_0ipnerm
-        ClientContext	Flow_1m4nc7r
+        ClientContext   Event_022qurv
+        ClientContext   Flow_09zlhyo
+        ClientContext   Flow_0ipnerm
+        ClientContext   Flow_1m4nc7r
     
         init
         Gateway_01j7v59 := ClientContext {
@@ -40,163 +40,180 @@ specification fries_comp
     
         desc "Activity_1nx4k9r_Model"
         
-        action			Activity_1z0bwek
-        case			default
-        with-inputs		Gateway_01j7v59
-        produces-outputs	Gateway_0bsgusg
+        action          Activity_1z0bwek
+        element-label   "Activity_1z0bwek"
+        case            default
+        with-inputs     Gateway_01j7v59
+        produces-outputs    Gateway_0bsgusg
         updates:
             Gateway_0bsgusg := Gateway_01j7v59
             Gateway_0bsgusg.fries.size := Size::Small
         
-        action			Activity_1nbx27m
-        case			default
-        with-inputs		Gateway_0bsgusg
-        with-guard		size(Gateway_0bsgusg.fries.style) < 3
-        produces-outputs	Gateway_0bsgusg
+        action          Activity_1nbx27m
+        element-label   "Activity_1nbx27m"
+        case            default
+        with-inputs     Gateway_0bsgusg
+        with-guard      size(Gateway_0bsgusg.fries.style) < 3
+        produces-outputs    Gateway_0bsgusg
         updates:
             Gateway_0bsgusg := Gateway_0bsgusg
             Gateway_0bsgusg.fries.style := add(Gateway_0bsgusg.fries.style, Topping::Mayo)
         
-        action			Activity_0b1ce28
-        case			default
-        with-inputs		Flow_09zlhyo, DataObjectReference_08usvro
-        with-guard		DataObjectReference_08usvro.clientOrder.client_id == Flow_09zlhyo.client_id
-        produces-outputs	Flow_0ipnerm
+        action          Activity_0b1ce28
+        element-label   "Activity_0b1ce28"
+        case            default
+        with-inputs     Flow_09zlhyo, DataObjectReference_08usvro
+        with-guard      DataObjectReference_08usvro.clientOrder.client_id == Flow_09zlhyo.client_id
+        produces-outputs    Flow_0ipnerm
         updates:
             Flow_0ipnerm := Flow_09zlhyo
-        produces-outputs	DataStoreReference_0kulgbq
+        produces-outputs    DataStoreReference_0kulgbq
         updates:    DataStoreReference_0kulgbq := DataObjectReference_08usvro
         
-        action			Activity_194q85o
-        case			default
-        with-inputs		Flow_1m4nc7r, DataStoreReference_0kulgbq
-        produces-outputs	Event_022qurv
+        action          Activity_194q85o
+        element-label   "Activity_194q85o"
+        case            default
+        with-inputs     Flow_1m4nc7r, DataStoreReference_0kulgbq
+        produces-outputs    Event_022qurv
         updates:
             Event_022qurv := Flow_1m4nc7r
         
-        action			Activity_1e34xy9
-        case			default
-        with-inputs		Gateway_0bsgusg
-        with-guard		Gateway_0bsgusg.fries.size != Size::Undefined
-        produces-outputs	Flow_09zlhyo
+        action          Activity_1e34xy9
+        element-label   "Activity_1e34xy9"
+        case            default
+        with-inputs     Gateway_0bsgusg
+        with-guard      Gateway_0bsgusg.fries.size != Size::Undefined
+        produces-outputs    Flow_09zlhyo
         updates:
             Flow_09zlhyo := Gateway_0bsgusg
-        produces-outputs	DataObjectReference_1kx41i3
+        produces-outputs    DataObjectReference_1kx41i3
         updates:    DataObjectReference_1kx41i3 := FriesOrder {
              client_id = Gateway_0bsgusg.client_id,
              fries = Gateway_0bsgusg.fries
             }
         
-        action			Activity_10xjyk8
-        case			default
-        with-inputs		Gateway_01j7v59
-        with-guard		Gateway_01j7v59.premium
-        produces-outputs	Gateway_0bsgusg
+        action          Activity_10xjyk8
+        element-label   "Activity_10xjyk8"
+        case            default
+        with-inputs     Gateway_01j7v59
+        with-guard      Gateway_01j7v59.premium
+        produces-outputs    Gateway_0bsgusg
         updates:
             Gateway_0bsgusg := Gateway_01j7v59
             Gateway_0bsgusg.fries.size := Size::Large
         
-        action			Activity_0sti0aj
-        case			default
-        with-inputs		Gateway_0bsgusg
-        with-guard		size(Gateway_0bsgusg.fries.style) < 3 AND Gateway_0bsgusg.premium
-        produces-outputs	Gateway_0bsgusg
+        action          Activity_0sti0aj
+        element-label   "Activity_0sti0aj"
+        case            default
+        with-inputs     Gateway_0bsgusg
+        with-guard      size(Gateway_0bsgusg.fries.style) < 3 AND Gateway_0bsgusg.premium
+        produces-outputs    Gateway_0bsgusg
         updates:
             Gateway_0bsgusg := Gateway_0bsgusg
             Gateway_0bsgusg.fries.style := add(Gateway_0bsgusg.fries.style, Topping::Onions)
         
-        action			Activity_033uadp
-        case			default
-        with-inputs		Gateway_01j7v59
-        produces-outputs	Gateway_0bsgusg
+        action          Activity_033uadp
+        element-label   "Activity_033uadp"
+        case            default
+        with-inputs     Gateway_01j7v59
+        produces-outputs    Gateway_0bsgusg
         updates:
             Gateway_0bsgusg := Gateway_01j7v59
             Gateway_0bsgusg.fries.size := Size::Medium
         
-        action			Activity_0migtdi
-        case			default
-        with-inputs		Gateway_0bsgusg
-        with-guard		size(Gateway_0bsgusg.fries.style) < 3
-        produces-outputs	Gateway_0bsgusg
+        action          Activity_0migtdi
+        element-label   "Activity_0migtdi"
+        case            default
+        with-inputs     Gateway_0bsgusg
+        with-guard      size(Gateway_0bsgusg.fries.style) < 3
+        produces-outputs    Gateway_0bsgusg
         updates:
             Gateway_0bsgusg := Gateway_0bsgusg
             Gateway_0bsgusg.fries.style := add(Gateway_0bsgusg.fries.style, Topping::Ketchup)
         
-        action			Activity_018jco6
-        case			default step-type "Check_Receipt" action-type ASSERT
-        with-inputs		Flow_0ipnerm, DataStoreReference_0kulgbq
-        with-guard		// TODO: Convert to assert task to avoid deadlocks!
+        action          Activity_018jco6
+        element-label   "Activity_018jco6"
+        case            default step-type "Check_Receipt" action-type ASSERT
+        with-inputs     Flow_0ipnerm, DataStoreReference_0kulgbq
+        with-guard      // TODO: Convert to assert task to avoid deadlocks!
         DataStoreReference_0kulgbq.clientOrder.fries == Flow_0ipnerm.fries
         assertions default {
             correct_amount: assert-that (DataStoreReference_0kulgbq.receipt.amount) {
               equal-to 5.0 within-margin absolute (0.50)
             }
         }
-        produces-outputs	Flow_1m4nc7r
+        produces-outputs    Flow_1m4nc7r
         updates:
             Flow_1m4nc7r := Flow_0ipnerm
-        produces-outputs	DataStoreReference_0kulgbq symbolic-link
+        produces-outputs    DataStoreReference_0kulgbq symbolic-link
         updates: DataStoreReference_0kulgbq := DataStoreReference_0kulgbq
+    
+        element-labels ["Process_1", "Activity_1nx4k9r"]
     }
     
     system Activity_18pdfak
     {
         inputs
-        FriesDelivery	DataObjectReference_1pzevyf
+        FriesDelivery   DataObjectReference_1pzevyf
         
         outputs
-        FriesDelivery		DataObjectReference_08usvro
+        FriesDelivery       DataObjectReference_08usvro
     
         local
         
-        DeliveryServiceContext	Event_00idax9
-        DeliveryServiceContext	Flow_0happwq
-        DeliveryServiceContext	Flow_1b6215f
+        DeliveryServiceContext  Event_00idax9
+        DeliveryServiceContext  Flow_0happwq
+        DeliveryServiceContext  Flow_1b6215f
     
         // init
     
     
         desc "Activity_18pdfak_Model"
         
-        action			Activity_19g7d8q
-        case			default
-        with-inputs		Flow_0happwq
-        produces-outputs	Event_00idax9
+        action          Activity_19g7d8q
+        element-label   "Activity_19g7d8q"
+        case            default
+        with-inputs     Flow_0happwq
+        produces-outputs    Event_00idax9
         updates:
             Event_00idax9 := Flow_0happwq
-        produces-outputs	DataObjectReference_08usvro
+        produces-outputs    DataObjectReference_08usvro
         updates:    DataObjectReference_08usvro := Flow_0happwq.delivery
         
-        action			Activity_0nh18fo
-        case			default
-        with-inputs		DataObjectReference_1pzevyf
-        produces-outputs	Flow_1b6215f
+        action          Activity_0nh18fo
+        element-label   "Activity_0nh18fo"
+        case            default
+        with-inputs     DataObjectReference_1pzevyf
+        produces-outputs    Flow_1b6215f
         updates:
             Flow_1b6215f := DeliveryServiceContext {
              delivery =  DataObjectReference_1pzevyf
             }
         
-        action			Activity_00tgl1w
-        case			default
-        with-inputs		Flow_1b6215f
-        produces-outputs	Flow_0happwq
+        action          Activity_00tgl1w
+        element-label   "Activity_00tgl1w"
+        case            default
+        with-inputs     Flow_1b6215f
+        produces-outputs    Flow_0happwq
         updates:
             Flow_0happwq := Flow_1b6215f
+    
+        element-labels ["Process_1", "Activity_18pdfak"]
     }
     
     system Activity_0n48uxi
     {
         inputs
-        FriesOrder	DataObjectReference_1kx41i3
+        FriesOrder  DataObjectReference_1kx41i3
         
         outputs
-        FriesDelivery		DataObjectReference_1pzevyf
+        FriesDelivery       DataObjectReference_1pzevyf
     
         local
-        SnackbarContext	Gateway_098asuz
-        SnackbarContext	Event_0uxsyhg
-        SnackbarContext	Event_04cb9z0
-        SnackbarContext	Flow_16vj7d4
+        SnackbarContext Gateway_098asuz
+        SnackbarContext Event_0uxsyhg
+        SnackbarContext Event_04cb9z0
+        SnackbarContext Flow_16vj7d4
     
         init
         Event_0uxsyhg := SnackbarContext {
@@ -207,44 +224,50 @@ specification fries_comp
     
         desc "Activity_0n48uxi_Model"
         
-        action			Activity_1180u0i
-        case			default
-        with-inputs		Flow_16vj7d4
-        produces-outputs	Gateway_098asuz
+        action          Activity_1180u0i
+        element-label   "Activity_1180u0i"
+        case            default
+        with-inputs     Flow_16vj7d4
+        produces-outputs    Gateway_098asuz
         updates:
             Gateway_098asuz := Flow_16vj7d4
         
-        action			Activity_0llc4s9
-        case			default
-        with-inputs		Gateway_098asuz, DataObjectReference_1kx41i3
-        with-guard		Gateway_098asuz.orders < 2
-        produces-outputs	Gateway_098asuz
+        action          Activity_0llc4s9
+        element-label   "Activity_0llc4s9"
+        case            default
+        with-inputs     Gateway_098asuz, DataObjectReference_1kx41i3
+        with-guard      Gateway_098asuz.orders < 2
+        produces-outputs    Gateway_098asuz
         updates:
             Gateway_098asuz := Gateway_098asuz
             Gateway_098asuz.orders := Gateway_098asuz.orders + 1
-        produces-outputs	DataObjectReference_1pzevyf
+        produces-outputs    DataObjectReference_1pzevyf
         updates:    DataObjectReference_1pzevyf := FriesDelivery {
              clientOrder = DataObjectReference_1kx41i3,
              receipt = Receipt { amount = 5.0 }
             }
         
-        action			Activity_15uaf19
-        case			default
-        with-inputs		Event_0uxsyhg
-        produces-outputs	Flow_16vj7d4
+        action          Activity_15uaf19
+        element-label   "Activity_15uaf19"
+        case            default
+        with-inputs     Event_0uxsyhg
+        produces-outputs    Flow_16vj7d4
         updates:
             Flow_16vj7d4 := Event_0uxsyhg
         
-        action			Activity_0957lig
-        case			default
-        with-inputs		Gateway_098asuz
-        with-guard		Gateway_098asuz.orders >= 2
-        produces-outputs	Event_04cb9z0
+        action          Activity_0957lig
+        element-label   "Activity_0957lig"
+        case            default
+        with-inputs     Gateway_098asuz
+        with-guard      Gateway_098asuz.orders >= 2
+        produces-outputs    Event_04cb9z0
         updates:
             Event_04cb9z0 := Gateway_098asuz
+    
+        element-labels ["Process_1", "Activity_0n48uxi"]
     }
     
-	SUT-blocks 
-	depth-limits 300
-	num-tests 1
+    SUT-blocks 
+    depth-limits 300
+    num-tests 1
 }

--- a/bundles/nl.asml.matala.bpmn4s.tests/resources/expected/fries_comp/fries_comp.ps
+++ b/bundles/nl.asml.matala.bpmn4s.tests/resources/expected/fries_comp/fries_comp.ps
@@ -4,20 +4,20 @@ specification fries_comp
     system Activity_1nx4k9r
     {
         inputs
-        FriesDelivery   DataObjectReference_08usvro
+        FriesDelivery	DataObjectReference_08usvro
         
         outputs
-        FriesOrder      DataObjectReference_1kx41i3
+        FriesOrder		DataObjectReference_1kx41i3
     
         local
-        FriesDelivery   DataStoreReference_0kulgbq
-        ClientContext   Gateway_0bsgusg
-        ClientContext   Gateway_01j7v59
+        FriesDelivery	DataStoreReference_0kulgbq
+        ClientContext	Gateway_0bsgusg
+        ClientContext	Gateway_01j7v59
         
-        ClientContext   Event_022qurv
-        ClientContext   Flow_09zlhyo
-        ClientContext   Flow_0ipnerm
-        ClientContext   Flow_1m4nc7r
+        ClientContext	Event_022qurv
+        ClientContext	Flow_09zlhyo
+        ClientContext	Flow_0ipnerm
+        ClientContext	Flow_1m4nc7r
     
         init
         Gateway_01j7v59 := ClientContext {
@@ -40,112 +40,112 @@ specification fries_comp
     
         desc "Activity_1nx4k9r_Model"
         
-        action          Activity_1z0bwek
-        element-label   "Activity_1z0bwek"
-        case            default
-        with-inputs     Gateway_01j7v59
-        produces-outputs    Gateway_0bsgusg
+        action			Activity_1z0bwek
+        element-label	"Activity_1z0bwek"
+        case			default
+        with-inputs		Gateway_01j7v59
+        produces-outputs	Gateway_0bsgusg
         updates:
             Gateway_0bsgusg := Gateway_01j7v59
             Gateway_0bsgusg.fries.size := Size::Small
         
-        action          Activity_1nbx27m
-        element-label   "Activity_1nbx27m"
-        case            default
-        with-inputs     Gateway_0bsgusg
-        with-guard      size(Gateway_0bsgusg.fries.style) < 3
-        produces-outputs    Gateway_0bsgusg
+        action			Activity_1nbx27m
+        element-label	"Activity_1nbx27m"
+        case			default
+        with-inputs		Gateway_0bsgusg
+        with-guard		size(Gateway_0bsgusg.fries.style) < 3
+        produces-outputs	Gateway_0bsgusg
         updates:
             Gateway_0bsgusg := Gateway_0bsgusg
             Gateway_0bsgusg.fries.style := add(Gateway_0bsgusg.fries.style, Topping::Mayo)
         
-        action          Activity_0b1ce28
-        element-label   "Activity_0b1ce28"
-        case            default
-        with-inputs     Flow_09zlhyo, DataObjectReference_08usvro
-        with-guard      DataObjectReference_08usvro.clientOrder.client_id == Flow_09zlhyo.client_id
-        produces-outputs    Flow_0ipnerm
+        action			Activity_0b1ce28
+        element-label	"Activity_0b1ce28"
+        case			default
+        with-inputs		Flow_09zlhyo, DataObjectReference_08usvro
+        with-guard		DataObjectReference_08usvro.clientOrder.client_id == Flow_09zlhyo.client_id
+        produces-outputs	Flow_0ipnerm
         updates:
             Flow_0ipnerm := Flow_09zlhyo
-        produces-outputs    DataStoreReference_0kulgbq
+        produces-outputs	DataStoreReference_0kulgbq
         updates:    DataStoreReference_0kulgbq := DataObjectReference_08usvro
         
-        action          Activity_194q85o
-        element-label   "Activity_194q85o"
-        case            default
-        with-inputs     Flow_1m4nc7r, DataStoreReference_0kulgbq
-        produces-outputs    Event_022qurv
+        action			Activity_194q85o
+        element-label	"Activity_194q85o"
+        case			default
+        with-inputs		Flow_1m4nc7r, DataStoreReference_0kulgbq
+        produces-outputs	Event_022qurv
         updates:
             Event_022qurv := Flow_1m4nc7r
         
-        action          Activity_1e34xy9
-        element-label   "Activity_1e34xy9"
-        case            default
-        with-inputs     Gateway_0bsgusg
-        with-guard      Gateway_0bsgusg.fries.size != Size::Undefined
-        produces-outputs    Flow_09zlhyo
+        action			Activity_1e34xy9
+        element-label	"Activity_1e34xy9"
+        case			default
+        with-inputs		Gateway_0bsgusg
+        with-guard		Gateway_0bsgusg.fries.size != Size::Undefined
+        produces-outputs	Flow_09zlhyo
         updates:
             Flow_09zlhyo := Gateway_0bsgusg
-        produces-outputs    DataObjectReference_1kx41i3
+        produces-outputs	DataObjectReference_1kx41i3
         updates:    DataObjectReference_1kx41i3 := FriesOrder {
              client_id = Gateway_0bsgusg.client_id,
              fries = Gateway_0bsgusg.fries
             }
         
-        action          Activity_10xjyk8
-        element-label   "Activity_10xjyk8"
-        case            default
-        with-inputs     Gateway_01j7v59
-        with-guard      Gateway_01j7v59.premium
-        produces-outputs    Gateway_0bsgusg
+        action			Activity_10xjyk8
+        element-label	"Activity_10xjyk8"
+        case			default
+        with-inputs		Gateway_01j7v59
+        with-guard		Gateway_01j7v59.premium
+        produces-outputs	Gateway_0bsgusg
         updates:
             Gateway_0bsgusg := Gateway_01j7v59
             Gateway_0bsgusg.fries.size := Size::Large
         
-        action          Activity_0sti0aj
-        element-label   "Activity_0sti0aj"
-        case            default
-        with-inputs     Gateway_0bsgusg
-        with-guard      size(Gateway_0bsgusg.fries.style) < 3 AND Gateway_0bsgusg.premium
-        produces-outputs    Gateway_0bsgusg
+        action			Activity_0sti0aj
+        element-label	"Activity_0sti0aj"
+        case			default
+        with-inputs		Gateway_0bsgusg
+        with-guard		size(Gateway_0bsgusg.fries.style) < 3 AND Gateway_0bsgusg.premium
+        produces-outputs	Gateway_0bsgusg
         updates:
             Gateway_0bsgusg := Gateway_0bsgusg
             Gateway_0bsgusg.fries.style := add(Gateway_0bsgusg.fries.style, Topping::Onions)
         
-        action          Activity_033uadp
-        element-label   "Activity_033uadp"
-        case            default
-        with-inputs     Gateway_01j7v59
-        produces-outputs    Gateway_0bsgusg
+        action			Activity_033uadp
+        element-label	"Activity_033uadp"
+        case			default
+        with-inputs		Gateway_01j7v59
+        produces-outputs	Gateway_0bsgusg
         updates:
             Gateway_0bsgusg := Gateway_01j7v59
             Gateway_0bsgusg.fries.size := Size::Medium
         
-        action          Activity_0migtdi
-        element-label   "Activity_0migtdi"
-        case            default
-        with-inputs     Gateway_0bsgusg
-        with-guard      size(Gateway_0bsgusg.fries.style) < 3
-        produces-outputs    Gateway_0bsgusg
+        action			Activity_0migtdi
+        element-label	"Activity_0migtdi"
+        case			default
+        with-inputs		Gateway_0bsgusg
+        with-guard		size(Gateway_0bsgusg.fries.style) < 3
+        produces-outputs	Gateway_0bsgusg
         updates:
             Gateway_0bsgusg := Gateway_0bsgusg
             Gateway_0bsgusg.fries.style := add(Gateway_0bsgusg.fries.style, Topping::Ketchup)
         
-        action          Activity_018jco6
-        element-label   "Activity_018jco6"
-        case            default step-type "Check_Receipt" action-type ASSERT
-        with-inputs     Flow_0ipnerm, DataStoreReference_0kulgbq
-        with-guard      // TODO: Convert to assert task to avoid deadlocks!
+        action			Activity_018jco6
+        element-label	"Activity_018jco6"
+        case			default step-type "Check_Receipt" action-type ASSERT
+        with-inputs		Flow_0ipnerm, DataStoreReference_0kulgbq
+        with-guard		// TODO: Convert to assert task to avoid deadlocks!
         DataStoreReference_0kulgbq.clientOrder.fries == Flow_0ipnerm.fries
         assertions default {
             correct_amount: assert-that (DataStoreReference_0kulgbq.receipt.amount) {
               equal-to 5.0 within-margin absolute (0.50)
             }
         }
-        produces-outputs    Flow_1m4nc7r
+        produces-outputs	Flow_1m4nc7r
         updates:
             Flow_1m4nc7r := Flow_0ipnerm
-        produces-outputs    DataStoreReference_0kulgbq symbolic-link
+        produces-outputs	DataStoreReference_0kulgbq symbolic-link
         updates: DataStoreReference_0kulgbq := DataStoreReference_0kulgbq
     
         element-labels ["Process_1", "Activity_1nx4k9r"]
@@ -154,47 +154,47 @@ specification fries_comp
     system Activity_18pdfak
     {
         inputs
-        FriesDelivery   DataObjectReference_1pzevyf
+        FriesDelivery	DataObjectReference_1pzevyf
         
         outputs
-        FriesDelivery       DataObjectReference_08usvro
+        FriesDelivery		DataObjectReference_08usvro
     
         local
         
-        DeliveryServiceContext  Event_00idax9
-        DeliveryServiceContext  Flow_0happwq
-        DeliveryServiceContext  Flow_1b6215f
+        DeliveryServiceContext	Event_00idax9
+        DeliveryServiceContext	Flow_0happwq
+        DeliveryServiceContext	Flow_1b6215f
     
         // init
     
     
         desc "Activity_18pdfak_Model"
         
-        action          Activity_19g7d8q
-        element-label   "Activity_19g7d8q"
-        case            default
-        with-inputs     Flow_0happwq
-        produces-outputs    Event_00idax9
+        action			Activity_19g7d8q
+        element-label	"Activity_19g7d8q"
+        case			default
+        with-inputs		Flow_0happwq
+        produces-outputs	Event_00idax9
         updates:
             Event_00idax9 := Flow_0happwq
-        produces-outputs    DataObjectReference_08usvro
+        produces-outputs	DataObjectReference_08usvro
         updates:    DataObjectReference_08usvro := Flow_0happwq.delivery
         
-        action          Activity_0nh18fo
-        element-label   "Activity_0nh18fo"
-        case            default
-        with-inputs     DataObjectReference_1pzevyf
-        produces-outputs    Flow_1b6215f
+        action			Activity_0nh18fo
+        element-label	"Activity_0nh18fo"
+        case			default
+        with-inputs		DataObjectReference_1pzevyf
+        produces-outputs	Flow_1b6215f
         updates:
             Flow_1b6215f := DeliveryServiceContext {
              delivery =  DataObjectReference_1pzevyf
             }
         
-        action          Activity_00tgl1w
-        element-label   "Activity_00tgl1w"
-        case            default
-        with-inputs     Flow_1b6215f
-        produces-outputs    Flow_0happwq
+        action			Activity_00tgl1w
+        element-label	"Activity_00tgl1w"
+        case			default
+        with-inputs		Flow_1b6215f
+        produces-outputs	Flow_0happwq
         updates:
             Flow_0happwq := Flow_1b6215f
     
@@ -204,16 +204,16 @@ specification fries_comp
     system Activity_0n48uxi
     {
         inputs
-        FriesOrder  DataObjectReference_1kx41i3
+        FriesOrder	DataObjectReference_1kx41i3
         
         outputs
-        FriesDelivery       DataObjectReference_1pzevyf
+        FriesDelivery		DataObjectReference_1pzevyf
     
         local
-        SnackbarContext Gateway_098asuz
-        SnackbarContext Event_0uxsyhg
-        SnackbarContext Event_04cb9z0
-        SnackbarContext Flow_16vj7d4
+        SnackbarContext	Gateway_098asuz
+        SnackbarContext	Event_0uxsyhg
+        SnackbarContext	Event_04cb9z0
+        SnackbarContext	Flow_16vj7d4
     
         init
         Event_0uxsyhg := SnackbarContext {
@@ -224,50 +224,50 @@ specification fries_comp
     
         desc "Activity_0n48uxi_Model"
         
-        action          Activity_1180u0i
-        element-label   "Activity_1180u0i"
-        case            default
-        with-inputs     Flow_16vj7d4
-        produces-outputs    Gateway_098asuz
+        action			Activity_1180u0i
+        element-label	"Activity_1180u0i"
+        case			default
+        with-inputs		Flow_16vj7d4
+        produces-outputs	Gateway_098asuz
         updates:
             Gateway_098asuz := Flow_16vj7d4
         
-        action          Activity_0llc4s9
-        element-label   "Activity_0llc4s9"
-        case            default
-        with-inputs     Gateway_098asuz, DataObjectReference_1kx41i3
-        with-guard      Gateway_098asuz.orders < 2
-        produces-outputs    Gateway_098asuz
+        action			Activity_0llc4s9
+        element-label	"Activity_0llc4s9"
+        case			default
+        with-inputs		Gateway_098asuz, DataObjectReference_1kx41i3
+        with-guard		Gateway_098asuz.orders < 2
+        produces-outputs	Gateway_098asuz
         updates:
             Gateway_098asuz := Gateway_098asuz
             Gateway_098asuz.orders := Gateway_098asuz.orders + 1
-        produces-outputs    DataObjectReference_1pzevyf
+        produces-outputs	DataObjectReference_1pzevyf
         updates:    DataObjectReference_1pzevyf := FriesDelivery {
              clientOrder = DataObjectReference_1kx41i3,
              receipt = Receipt { amount = 5.0 }
             }
         
-        action          Activity_15uaf19
-        element-label   "Activity_15uaf19"
-        case            default
-        with-inputs     Event_0uxsyhg
-        produces-outputs    Flow_16vj7d4
+        action			Activity_15uaf19
+        element-label	"Activity_15uaf19"
+        case			default
+        with-inputs		Event_0uxsyhg
+        produces-outputs	Flow_16vj7d4
         updates:
             Flow_16vj7d4 := Event_0uxsyhg
         
-        action          Activity_0957lig
-        element-label   "Activity_0957lig"
-        case            default
-        with-inputs     Gateway_098asuz
-        with-guard      Gateway_098asuz.orders >= 2
-        produces-outputs    Event_04cb9z0
+        action			Activity_0957lig
+        element-label	"Activity_0957lig"
+        case			default
+        with-inputs		Gateway_098asuz
+        with-guard		Gateway_098asuz.orders >= 2
+        produces-outputs	Event_04cb9z0
         updates:
             Event_04cb9z0 := Gateway_098asuz
     
         element-labels ["Process_1", "Activity_0n48uxi"]
     }
     
-    SUT-blocks 
-    depth-limits 300
-    num-tests 1
+	SUT-blocks 
+	depth-limits 300
+	num-tests 1
 }

--- a/bundles/nl.asml.matala.bpmn4s.tests/resources/expected/fries_flat/fries_flat.ps
+++ b/bundles/nl.asml.matala.bpmn4s.tests/resources/expected/fries_flat/fries_flat.ps
@@ -8,16 +8,16 @@ specification fries_flat
         //outputs
     
         local
-        Fries   DataStoreReference_03v9xko
-        Topping DataStoreReference_18a07df
-        FriesContext    Gateway_19p4wo1
-        FriesContext    Gateway_0k04hvx
-        FriesContext    Event_0a5g9gv
-        FriesContext    Event_1vt9n85
-        FriesContext    Flow_1fk5b3r
-        FriesContext    Flow_003weme
-        FriesContext    Flow_0z70hyg
-        FriesContext    Flow_0bwi85w
+        Fries	DataStoreReference_03v9xko
+        Topping	DataStoreReference_18a07df
+        FriesContext	Gateway_19p4wo1
+        FriesContext	Gateway_0k04hvx
+        FriesContext	Event_0a5g9gv
+        FriesContext	Event_1vt9n85
+        FriesContext	Flow_1fk5b3r
+        FriesContext	Flow_003weme
+        FriesContext	Flow_0z70hyg
+        FriesContext	Flow_0bwi85w
     
         init
         Event_0a5g9gv := FriesContext { client_id = "Tom" }
@@ -26,87 +26,87 @@ specification fries_flat
     
         desc "Process_1_Model"
         
-        action          Activity_01x82y5
-        element-label   "Activity_01x82y5"
-        case            default
-        with-inputs     Gateway_19p4wo1
-        with-guard      Gateway_19p4wo1.client_id == "Tom"
-        produces-outputs    Gateway_0k04hvx
+        action			Activity_01x82y5
+        element-label	"Activity_01x82y5"
+        case			default
+        with-inputs		Gateway_19p4wo1
+        with-guard		Gateway_19p4wo1.client_id == "Tom"
+        produces-outputs	Gateway_0k04hvx
         updates:
             Gateway_0k04hvx := Gateway_19p4wo1
-        produces-outputs    DataStoreReference_18a07df
+        produces-outputs	DataStoreReference_18a07df
         updates:    DataStoreReference_18a07df := Topping {
              ctx = Gateway_19p4wo1,
              sauce = Sauce::Ketchup
             }
         
-        action          Activity_0par2jr
-        element-label   "Activity_0par2jr"
-        case            default
-        with-inputs     Gateway_19p4wo1
-        produces-outputs    Gateway_0k04hvx
+        action			Activity_0par2jr
+        element-label	"Activity_0par2jr"
+        case			default
+        with-inputs		Gateway_19p4wo1
+        produces-outputs	Gateway_0k04hvx
         updates:
             Gateway_0k04hvx := Gateway_19p4wo1
-        produces-outputs    DataStoreReference_18a07df
+        produces-outputs	DataStoreReference_18a07df
         updates:    DataStoreReference_18a07df := Topping {
              ctx = Gateway_19p4wo1,
              sauce = Sauce::Mayo
             }
         
-        action          Activity_19yirph
-        element-label   "Activity_19yirph"
-        case            default
-        with-inputs     Flow_1fk5b3r, DataStoreReference_18a07df
-        with-guard      DataStoreReference_18a07df.ctx == Flow_1fk5b3r
-        produces-outputs    Flow_003weme
+        action			Activity_19yirph
+        element-label	"Activity_19yirph"
+        case			default
+        with-inputs		Flow_1fk5b3r, DataStoreReference_18a07df
+        with-guard		DataStoreReference_18a07df.ctx == Flow_1fk5b3r
+        produces-outputs	Flow_003weme
         updates:
             Flow_003weme := Flow_1fk5b3r
-        produces-outputs    DataStoreReference_03v9xko
+        produces-outputs	DataStoreReference_03v9xko
         updates:    DataStoreReference_03v9xko := Fries {
              dressing = DataStoreReference_18a07df,
              client_id = Flow_1fk5b3r.client_id
             }
         
-        action          Gateway_0dqgx0i
-        element-label   "Gateway_0dqgx0i"
-        case            default
-        with-inputs     Event_0a5g9gv
-        produces-outputs    Gateway_19p4wo1
+        action			Gateway_0dqgx0i
+        element-label	"Gateway_0dqgx0i"
+        case			default
+        with-inputs		Event_0a5g9gv
+        produces-outputs	Gateway_19p4wo1
         updates:
             Gateway_19p4wo1 := Event_0a5g9gv
-        produces-outputs    Flow_0z70hyg
+        produces-outputs	Flow_0z70hyg
         updates:
             Flow_0z70hyg := Event_0a5g9gv
         
-        action          Activity_0uiz2cy
-        element-label   "Activity_0uiz2cy"
-        case            default
-        with-inputs     Flow_0bwi85w, DataStoreReference_03v9xko
-        produces-outputs    Event_1vt9n85
+        action			Activity_0uiz2cy
+        element-label	"Activity_0uiz2cy"
+        case			default
+        with-inputs		Flow_0bwi85w, DataStoreReference_03v9xko
+        produces-outputs	Event_1vt9n85
         updates:
             Event_1vt9n85 := Flow_0bwi85w
         
-        action          Activity_1fzja8h
-        element-label   "Activity_1fzja8h"
-        case            default
-        with-inputs     Flow_0z70hyg
-        produces-outputs    Flow_1fk5b3r
+        action			Activity_1fzja8h
+        element-label	"Activity_1fzja8h"
+        case			default
+        with-inputs		Flow_0z70hyg
+        produces-outputs	Flow_1fk5b3r
         updates:
             Flow_1fk5b3r := Flow_0z70hyg
         
-        action          Gateway_1w5n2dh
-        element-label   "Gateway_1w5n2dh"
-        case            default
-        with-inputs     Flow_003weme, Gateway_0k04hvx
-        with-guard      Gateway_0k04hvx == Flow_003weme
-        produces-outputs    Flow_0bwi85w
+        action			Gateway_1w5n2dh
+        element-label	"Gateway_1w5n2dh"
+        case			default
+        with-inputs		Flow_003weme, Gateway_0k04hvx
+        with-guard		Gateway_0k04hvx == Flow_003weme
+        produces-outputs	Flow_0bwi85w
         updates:
             Flow_0bwi85w := Flow_003weme
     
         element-labels ["Process_1"]
     }
     
-    SUT-blocks 
-    depth-limits 300
-    num-tests 1
+	SUT-blocks 
+	depth-limits 300
+	num-tests 1
 }

--- a/bundles/nl.asml.matala.bpmn4s.tests/resources/expected/fries_flat/fries_flat.ps
+++ b/bundles/nl.asml.matala.bpmn4s.tests/resources/expected/fries_flat/fries_flat.ps
@@ -8,16 +8,16 @@ specification fries_flat
         //outputs
     
         local
-        Fries	DataStoreReference_03v9xko
-        Topping	DataStoreReference_18a07df
-        FriesContext	Gateway_19p4wo1
-        FriesContext	Gateway_0k04hvx
-        FriesContext	Event_0a5g9gv
-        FriesContext	Event_1vt9n85
-        FriesContext	Flow_1fk5b3r
-        FriesContext	Flow_003weme
-        FriesContext	Flow_0z70hyg
-        FriesContext	Flow_0bwi85w
+        Fries   DataStoreReference_03v9xko
+        Topping DataStoreReference_18a07df
+        FriesContext    Gateway_19p4wo1
+        FriesContext    Gateway_0k04hvx
+        FriesContext    Event_0a5g9gv
+        FriesContext    Event_1vt9n85
+        FriesContext    Flow_1fk5b3r
+        FriesContext    Flow_003weme
+        FriesContext    Flow_0z70hyg
+        FriesContext    Flow_0bwi85w
     
         init
         Event_0a5g9gv := FriesContext { client_id = "Tom" }
@@ -26,78 +26,87 @@ specification fries_flat
     
         desc "Process_1_Model"
         
-        action			Activity_01x82y5
-        case			default
-        with-inputs		Gateway_19p4wo1
-        with-guard		Gateway_19p4wo1.client_id == "Tom"
-        produces-outputs	Gateway_0k04hvx
+        action          Activity_01x82y5
+        element-label   "Activity_01x82y5"
+        case            default
+        with-inputs     Gateway_19p4wo1
+        with-guard      Gateway_19p4wo1.client_id == "Tom"
+        produces-outputs    Gateway_0k04hvx
         updates:
             Gateway_0k04hvx := Gateway_19p4wo1
-        produces-outputs	DataStoreReference_18a07df
+        produces-outputs    DataStoreReference_18a07df
         updates:    DataStoreReference_18a07df := Topping {
              ctx = Gateway_19p4wo1,
              sauce = Sauce::Ketchup
             }
         
-        action			Activity_0par2jr
-        case			default
-        with-inputs		Gateway_19p4wo1
-        produces-outputs	Gateway_0k04hvx
+        action          Activity_0par2jr
+        element-label   "Activity_0par2jr"
+        case            default
+        with-inputs     Gateway_19p4wo1
+        produces-outputs    Gateway_0k04hvx
         updates:
             Gateway_0k04hvx := Gateway_19p4wo1
-        produces-outputs	DataStoreReference_18a07df
+        produces-outputs    DataStoreReference_18a07df
         updates:    DataStoreReference_18a07df := Topping {
              ctx = Gateway_19p4wo1,
              sauce = Sauce::Mayo
             }
         
-        action			Activity_19yirph
-        case			default
-        with-inputs		Flow_1fk5b3r, DataStoreReference_18a07df
-        with-guard		DataStoreReference_18a07df.ctx == Flow_1fk5b3r
-        produces-outputs	Flow_003weme
+        action          Activity_19yirph
+        element-label   "Activity_19yirph"
+        case            default
+        with-inputs     Flow_1fk5b3r, DataStoreReference_18a07df
+        with-guard      DataStoreReference_18a07df.ctx == Flow_1fk5b3r
+        produces-outputs    Flow_003weme
         updates:
             Flow_003weme := Flow_1fk5b3r
-        produces-outputs	DataStoreReference_03v9xko
+        produces-outputs    DataStoreReference_03v9xko
         updates:    DataStoreReference_03v9xko := Fries {
              dressing = DataStoreReference_18a07df,
              client_id = Flow_1fk5b3r.client_id
             }
         
-        action			Gateway_0dqgx0i
-        case			default
-        with-inputs		Event_0a5g9gv
-        produces-outputs	Gateway_19p4wo1
+        action          Gateway_0dqgx0i
+        element-label   "Gateway_0dqgx0i"
+        case            default
+        with-inputs     Event_0a5g9gv
+        produces-outputs    Gateway_19p4wo1
         updates:
             Gateway_19p4wo1 := Event_0a5g9gv
-        produces-outputs	Flow_0z70hyg
+        produces-outputs    Flow_0z70hyg
         updates:
             Flow_0z70hyg := Event_0a5g9gv
         
-        action			Activity_0uiz2cy
-        case			default
-        with-inputs		Flow_0bwi85w, DataStoreReference_03v9xko
-        produces-outputs	Event_1vt9n85
+        action          Activity_0uiz2cy
+        element-label   "Activity_0uiz2cy"
+        case            default
+        with-inputs     Flow_0bwi85w, DataStoreReference_03v9xko
+        produces-outputs    Event_1vt9n85
         updates:
             Event_1vt9n85 := Flow_0bwi85w
         
-        action			Activity_1fzja8h
-        case			default
-        with-inputs		Flow_0z70hyg
-        produces-outputs	Flow_1fk5b3r
+        action          Activity_1fzja8h
+        element-label   "Activity_1fzja8h"
+        case            default
+        with-inputs     Flow_0z70hyg
+        produces-outputs    Flow_1fk5b3r
         updates:
             Flow_1fk5b3r := Flow_0z70hyg
         
-        action			Gateway_1w5n2dh
-        case			default
-        with-inputs		Flow_003weme, Gateway_0k04hvx
-        with-guard		Gateway_0k04hvx == Flow_003weme
-        produces-outputs	Flow_0bwi85w
+        action          Gateway_1w5n2dh
+        element-label   "Gateway_1w5n2dh"
+        case            default
+        with-inputs     Flow_003weme, Gateway_0k04hvx
+        with-guard      Gateway_0k04hvx == Flow_003weme
+        produces-outputs    Flow_0bwi85w
         updates:
             Flow_0bwi85w := Flow_003weme
+    
+        element-labels ["Process_1"]
     }
     
-	SUT-blocks 
-	depth-limits 300
-	num-tests 1
+    SUT-blocks 
+    depth-limits 300
+    num-tests 1
 }

--- a/bundles/nl.asml.matala.bpmn4s.tests/resources/expected/fries_sub/fries_sub.ps
+++ b/bundles/nl.asml.matala.bpmn4s.tests/resources/expected/fries_sub/fries_sub.ps
@@ -8,18 +8,18 @@ specification fries_sub
         //outputs
     
         local
-        Fries	DataStoreReference_03v9xko
-        Topping	DataStoreReference_18a07df
-        FriesContext	Gateway_005ldi2
-        FriesContext	Gateway_05dn8q0
-        FriesContext	Event_0a5g9gv
-        FriesContext	Event_1vt9n85
-        FriesContext	Flow_003weme
-        FriesContext	Flow_0sre3lm
-        FriesContext	Flow_0cyzh2k
-        FriesContext	Flow_0rmtq35
-        FriesContext	Flow_0z70hyg
-        FriesContext	Flow_0bwi85w
+        Fries   DataStoreReference_03v9xko
+        Topping DataStoreReference_18a07df
+        FriesContext    Gateway_005ldi2
+        FriesContext    Gateway_05dn8q0
+        FriesContext    Event_0a5g9gv
+        FriesContext    Event_1vt9n85
+        FriesContext    Flow_003weme
+        FriesContext    Flow_0sre3lm
+        FriesContext    Flow_0cyzh2k
+        FriesContext    Flow_0rmtq35
+        FriesContext    Flow_0z70hyg
+        FriesContext    Flow_0bwi85w
     
         init
         Event_0a5g9gv := FriesContext { client_id = "Tom" }
@@ -28,92 +28,103 @@ specification fries_sub
     
         desc "Process_1_Model"
         
-        action			Gateway_0dqgx0i
-        case			default
-        with-inputs		Event_0a5g9gv
-        produces-outputs	Gateway_005ldi2
+        action          Gateway_0dqgx0i
+        element-label   "Gateway_0dqgx0i"
+        case            default
+        with-inputs     Event_0a5g9gv
+        produces-outputs    Gateway_005ldi2
         updates:
             Gateway_005ldi2 := Event_0a5g9gv
-        produces-outputs	Flow_0z70hyg
+        produces-outputs    Flow_0z70hyg
         updates:
             Flow_0z70hyg := Event_0a5g9gv
         
-        action			Activity_07i3rou
-        case			default
-        with-inputs		Flow_0z70hyg
-        produces-outputs	Flow_0cyzh2k
+        action          Activity_07i3rou
+        element-label   "Activity_07i3rou"
+        case            default
+        with-inputs     Flow_0z70hyg
+        produces-outputs    Flow_0cyzh2k
         updates:
             Flow_0cyzh2k := Flow_0z70hyg
         
-        action			Gateway_1w5n2dh
-        case			default
-        with-inputs		Gateway_05dn8q0, Flow_003weme
-        with-guard		Flow_003weme == Gateway_05dn8q0
-        produces-outputs	Flow_0bwi85w
+        action          Gateway_1w5n2dh
+        element-label   "Gateway_1w5n2dh"
+        case            default
+        with-inputs     Gateway_05dn8q0, Flow_003weme
+        with-guard      Flow_003weme == Gateway_05dn8q0
+        produces-outputs    Flow_0bwi85w
         updates:
             Flow_0bwi85w := Gateway_05dn8q0
         
-        action			Activity_19u0wpe
-        case			default
-        with-inputs		Flow_0sre3lm, DataStoreReference_18a07df
-        with-guard		DataStoreReference_18a07df.ctx == Flow_0sre3lm
-        produces-outputs	Flow_003weme
+        action          Activity_19u0wpe
+        element-label   "Activity_19u0wpe"
+        case            default
+        with-inputs     Flow_0sre3lm, DataStoreReference_18a07df
+        with-guard      DataStoreReference_18a07df.ctx == Flow_0sre3lm
+        produces-outputs    Flow_003weme
         updates:
             Flow_003weme := Flow_0sre3lm
-        produces-outputs	DataStoreReference_03v9xko
+        produces-outputs    DataStoreReference_03v9xko
         updates:    DataStoreReference_03v9xko := Fries {
              dressing = DataStoreReference_18a07df,
              client_id = Flow_0sre3lm.client_id
             }
         
-        action			Activity_0zj3anq
-        case			default
-        with-inputs		Flow_0rmtq35
-        produces-outputs	Flow_0sre3lm
+        action          Activity_0zj3anq
+        element-label   "Activity_0zj3anq"
+        case            default
+        with-inputs     Flow_0rmtq35
+        produces-outputs    Flow_0sre3lm
         updates:
             Flow_0sre3lm := Flow_0rmtq35
         
-        action			Activity_0uiz2cy
-        case			default
-        with-inputs		Flow_0bwi85w, DataStoreReference_03v9xko
-        produces-outputs	Event_1vt9n85
+        action          Activity_0uiz2cy
+        element-label   "Activity_0uiz2cy"
+        case            default
+        with-inputs     Flow_0bwi85w, DataStoreReference_03v9xko
+        produces-outputs    Event_1vt9n85
         updates:
             Event_1vt9n85 := Flow_0bwi85w
         
-        action			Activity_10x5vyi
-        case			default
-        with-inputs		Gateway_005ldi2
-        produces-outputs	Gateway_05dn8q0
+        action          Activity_10x5vyi
+        element-label   "Activity_10x5vyi"
+        case            default
+        with-inputs     Gateway_005ldi2
+        produces-outputs    Gateway_05dn8q0
         updates:
             Gateway_05dn8q0 := Gateway_005ldi2
-        produces-outputs	DataStoreReference_18a07df
+        produces-outputs    DataStoreReference_18a07df
         updates:    DataStoreReference_18a07df := Topping {
              ctx = Gateway_005ldi2,
              sauce = Sauce::Mayo
             }
         
-        action			Activity_0memqtl
-        case			default
-        with-inputs		Flow_0cyzh2k
-        produces-outputs	Flow_0rmtq35
+        action          Activity_0memqtl
+        element-label   "Activity_0memqtl"
+        case            default
+        with-inputs     Flow_0cyzh2k
+        produces-outputs    Flow_0rmtq35
         updates:
             Flow_0rmtq35 := Flow_0cyzh2k
         
-        action			Activity_1g9tzja
-        case			default
-        with-inputs		Gateway_005ldi2
-        with-guard		Gateway_005ldi2.client_id == "Tom"
-        produces-outputs	Gateway_05dn8q0
+        action          Activity_1g9tzja
+        element-label   "Activity_1g9tzja"
+        case            default
+        with-inputs     Gateway_005ldi2
+        with-guard      Gateway_005ldi2.client_id == "Tom"
+        produces-outputs    Gateway_05dn8q0
         updates:
             Gateway_05dn8q0 := Gateway_005ldi2
-        produces-outputs	DataStoreReference_18a07df
+        produces-outputs    DataStoreReference_18a07df
         updates:    DataStoreReference_18a07df := Topping {
              ctx = Gateway_005ldi2,
              sauce = Sauce::Ketchup
             }
+    
+        element-labels ["Process_1"]
     }
     
-	SUT-blocks 
-	depth-limits 300
-	num-tests 1
+    SUT-blocks 
+    depth-limits 300
+    num-tests 1
 }

--- a/bundles/nl.asml.matala.bpmn4s.tests/resources/expected/fries_sub/fries_sub.ps
+++ b/bundles/nl.asml.matala.bpmn4s.tests/resources/expected/fries_sub/fries_sub.ps
@@ -8,18 +8,18 @@ specification fries_sub
         //outputs
     
         local
-        Fries   DataStoreReference_03v9xko
-        Topping DataStoreReference_18a07df
-        FriesContext    Gateway_005ldi2
-        FriesContext    Gateway_05dn8q0
-        FriesContext    Event_0a5g9gv
-        FriesContext    Event_1vt9n85
-        FriesContext    Flow_003weme
-        FriesContext    Flow_0sre3lm
-        FriesContext    Flow_0cyzh2k
-        FriesContext    Flow_0rmtq35
-        FriesContext    Flow_0z70hyg
-        FriesContext    Flow_0bwi85w
+        Fries	DataStoreReference_03v9xko
+        Topping	DataStoreReference_18a07df
+        FriesContext	Gateway_005ldi2
+        FriesContext	Gateway_05dn8q0
+        FriesContext	Event_0a5g9gv
+        FriesContext	Event_1vt9n85
+        FriesContext	Flow_003weme
+        FriesContext	Flow_0sre3lm
+        FriesContext	Flow_0cyzh2k
+        FriesContext	Flow_0rmtq35
+        FriesContext	Flow_0z70hyg
+        FriesContext	Flow_0bwi85w
     
         init
         Event_0a5g9gv := FriesContext { client_id = "Tom" }
@@ -28,94 +28,94 @@ specification fries_sub
     
         desc "Process_1_Model"
         
-        action          Gateway_0dqgx0i
-        element-label   "Gateway_0dqgx0i"
-        case            default
-        with-inputs     Event_0a5g9gv
-        produces-outputs    Gateway_005ldi2
+        action			Gateway_0dqgx0i
+        element-label	"Gateway_0dqgx0i"
+        case			default
+        with-inputs		Event_0a5g9gv
+        produces-outputs	Gateway_005ldi2
         updates:
             Gateway_005ldi2 := Event_0a5g9gv
-        produces-outputs    Flow_0z70hyg
+        produces-outputs	Flow_0z70hyg
         updates:
             Flow_0z70hyg := Event_0a5g9gv
         
-        action          Activity_07i3rou
-        element-label   "Activity_07i3rou"
-        case            default
-        with-inputs     Flow_0z70hyg
-        produces-outputs    Flow_0cyzh2k
+        action			Activity_07i3rou
+        element-label	"Activity_07i3rou"
+        case			default
+        with-inputs		Flow_0z70hyg
+        produces-outputs	Flow_0cyzh2k
         updates:
             Flow_0cyzh2k := Flow_0z70hyg
         
-        action          Gateway_1w5n2dh
-        element-label   "Gateway_1w5n2dh"
-        case            default
-        with-inputs     Gateway_05dn8q0, Flow_003weme
-        with-guard      Flow_003weme == Gateway_05dn8q0
-        produces-outputs    Flow_0bwi85w
+        action			Gateway_1w5n2dh
+        element-label	"Gateway_1w5n2dh"
+        case			default
+        with-inputs		Gateway_05dn8q0, Flow_003weme
+        with-guard		Flow_003weme == Gateway_05dn8q0
+        produces-outputs	Flow_0bwi85w
         updates:
             Flow_0bwi85w := Gateway_05dn8q0
         
-        action          Activity_19u0wpe
-        element-label   "Activity_19u0wpe"
-        case            default
-        with-inputs     Flow_0sre3lm, DataStoreReference_18a07df
-        with-guard      DataStoreReference_18a07df.ctx == Flow_0sre3lm
-        produces-outputs    Flow_003weme
+        action			Activity_19u0wpe
+        element-label	"Activity_19u0wpe"
+        case			default
+        with-inputs		Flow_0sre3lm, DataStoreReference_18a07df
+        with-guard		DataStoreReference_18a07df.ctx == Flow_0sre3lm
+        produces-outputs	Flow_003weme
         updates:
             Flow_003weme := Flow_0sre3lm
-        produces-outputs    DataStoreReference_03v9xko
+        produces-outputs	DataStoreReference_03v9xko
         updates:    DataStoreReference_03v9xko := Fries {
              dressing = DataStoreReference_18a07df,
              client_id = Flow_0sre3lm.client_id
             }
         
-        action          Activity_0zj3anq
-        element-label   "Activity_0zj3anq"
-        case            default
-        with-inputs     Flow_0rmtq35
-        produces-outputs    Flow_0sre3lm
+        action			Activity_0zj3anq
+        element-label	"Activity_0zj3anq"
+        case			default
+        with-inputs		Flow_0rmtq35
+        produces-outputs	Flow_0sre3lm
         updates:
             Flow_0sre3lm := Flow_0rmtq35
         
-        action          Activity_0uiz2cy
-        element-label   "Activity_0uiz2cy"
-        case            default
-        with-inputs     Flow_0bwi85w, DataStoreReference_03v9xko
-        produces-outputs    Event_1vt9n85
+        action			Activity_0uiz2cy
+        element-label	"Activity_0uiz2cy"
+        case			default
+        with-inputs		Flow_0bwi85w, DataStoreReference_03v9xko
+        produces-outputs	Event_1vt9n85
         updates:
             Event_1vt9n85 := Flow_0bwi85w
         
-        action          Activity_10x5vyi
-        element-label   "Activity_10x5vyi"
-        case            default
-        with-inputs     Gateway_005ldi2
-        produces-outputs    Gateway_05dn8q0
+        action			Activity_10x5vyi
+        element-label	"Activity_10x5vyi"
+        case			default
+        with-inputs		Gateway_005ldi2
+        produces-outputs	Gateway_05dn8q0
         updates:
             Gateway_05dn8q0 := Gateway_005ldi2
-        produces-outputs    DataStoreReference_18a07df
+        produces-outputs	DataStoreReference_18a07df
         updates:    DataStoreReference_18a07df := Topping {
              ctx = Gateway_005ldi2,
              sauce = Sauce::Mayo
             }
         
-        action          Activity_0memqtl
-        element-label   "Activity_0memqtl"
-        case            default
-        with-inputs     Flow_0cyzh2k
-        produces-outputs    Flow_0rmtq35
+        action			Activity_0memqtl
+        element-label	"Activity_0memqtl"
+        case			default
+        with-inputs		Flow_0cyzh2k
+        produces-outputs	Flow_0rmtq35
         updates:
             Flow_0rmtq35 := Flow_0cyzh2k
         
-        action          Activity_1g9tzja
-        element-label   "Activity_1g9tzja"
-        case            default
-        with-inputs     Gateway_005ldi2
-        with-guard      Gateway_005ldi2.client_id == "Tom"
-        produces-outputs    Gateway_05dn8q0
+        action			Activity_1g9tzja
+        element-label	"Activity_1g9tzja"
+        case			default
+        with-inputs		Gateway_005ldi2
+        with-guard		Gateway_005ldi2.client_id == "Tom"
+        produces-outputs	Gateway_05dn8q0
         updates:
             Gateway_05dn8q0 := Gateway_005ldi2
-        produces-outputs    DataStoreReference_18a07df
+        produces-outputs	DataStoreReference_18a07df
         updates:    DataStoreReference_18a07df := Topping {
              ctx = Gateway_005ldi2,
              sauce = Sauce::Ketchup
@@ -124,7 +124,7 @@ specification fries_sub
         element-labels ["Process_1"]
     }
     
-    SUT-blocks 
-    depth-limits 300
-    num-tests 1
+	SUT-blocks 
+	depth-limits 300
+	num-tests 1
 }

--- a/bundles/nl.asml.matala.bpmn4s.tests/resources/expected/printer_sim/printer.ps
+++ b/bundles/nl.asml.matala.bpmn4s.tests/resources/expected/printer_sim/printer.ps
@@ -4,20 +4,20 @@ specification printer
     system Activity_1lazkw7
     {
         inputs
-        PrintRequest	DataObjectReference_0dobbvk
-        CorrectionsReport	DataStoreReference_18mx7a8
+        PrintRequest    DataObjectReference_0dobbvk
+        CorrectionsReport   DataStoreReference_18mx7a8
         
         outputs
-        Result		DataObjectReference_15zyq6c
-        Report		DataStoreReference_0zb46u3
+        Result      DataObjectReference_15zyq6c
+        Report      DataStoreReference_0zb46u3
     
         local
-        PrintRequest	DataStoreReference_1221tl9
+        PrintRequest    DataStoreReference_1221tl9
         
-        UNIT	Event_0mxx05p
-        UNIT	Event_0jcg6zx
-        UNIT	Flow_1u2qmtt
-        UNIT	Flow_0iaelzn
+        UNIT    Event_0mxx05p
+        UNIT    Event_0jcg6zx
+        UNIT    Flow_1u2qmtt
+        UNIT    Flow_0iaelzn
     
         init
         DataStoreReference_18mx7a8 := CorrectionsReport { 
@@ -37,130 +37,142 @@ specification printer
     
         desc "Activity_1lazkw7_Model"
         
-        action			Activity_13k0eiw
-        case			default step-type "ExecutePrinter" action-type RUN
-        with-inputs		Flow_1u2qmtt, DataStoreReference_1221tl9
-        produces-outputs	Event_0jcg6zx suppress
+        action          Activity_13k0eiw
+        element-label   "Activity_13k0eiw"
+        case            default step-type "ExecutePrinter" action-type RUN
+        with-inputs     Flow_1u2qmtt, DataStoreReference_1221tl9
+        produces-outputs    Event_0jcg6zx suppress
         updates:
             Event_0jcg6zx := Flow_1u2qmtt
-        produces-outputs	DataObjectReference_15zyq6c
+        produces-outputs    DataObjectReference_15zyq6c
         updates:    DataObjectReference_15zyq6c := Result { verdict = Outcome::OK }
-        produces-outputs	DataStoreReference_0zb46u3 symbolic-link
+        produces-outputs    DataStoreReference_0zb46u3 symbolic-link
         updates:    DataStoreReference_0zb46u3 := Report {
              id = DataStoreReference_1221tl9.id
             }
         
-        action			Activity_0kjg94e
-        case			default step-type "null" action-type COMPOSE
-        with-inputs		DataObjectReference_0dobbvk, DataStoreReference_18mx7a8
-        with-guard		DataStoreReference_18mx7a8.id == DataObjectReference_0dobbvk.id and DataObjectReference_0dobbvk.opType == OperationType::PRINT
-        produces-outputs	Flow_1u2qmtt suppress
-        produces-outputs	DataStoreReference_1221tl9 symbolic-link
+        action          Activity_0kjg94e
+        element-label   "Activity_0kjg94e"
+        case            default step-type "null" action-type COMPOSE
+        with-inputs     DataObjectReference_0dobbvk, DataStoreReference_18mx7a8
+        with-guard      DataStoreReference_18mx7a8.id == DataObjectReference_0dobbvk.id and DataObjectReference_0dobbvk.opType == OperationType::PRINT
+        produces-outputs    Flow_1u2qmtt suppress
+        produces-outputs    DataStoreReference_1221tl9 symbolic-link
         updates:    DataStoreReference_1221tl9 := DataObjectReference_0dobbvk
         
-        action			Activity_10lpfzr
-        case			default step-type "null" action-type COMPOSE
-        with-inputs		DataObjectReference_0dobbvk
-        with-guard		DataObjectReference_0dobbvk.opType == OperationType::PREP
-        produces-outputs	Flow_0iaelzn suppress
-        produces-outputs	DataStoreReference_1221tl9 symbolic-link
+        action          Activity_10lpfzr
+        element-label   "Activity_10lpfzr"
+        case            default step-type "null" action-type COMPOSE
+        with-inputs     DataObjectReference_0dobbvk
+        with-guard      DataObjectReference_0dobbvk.opType == OperationType::PREP
+        produces-outputs    Flow_0iaelzn suppress
+        produces-outputs    DataStoreReference_1221tl9 symbolic-link
         updates:    DataStoreReference_1221tl9 := DataObjectReference_0dobbvk
         
-        action			Activity_0kyb9u9
-        case			default step-type "ExecutePrinter" action-type RUN
-        with-inputs		Flow_0iaelzn, DataStoreReference_1221tl9
-        produces-outputs	Event_0mxx05p suppress
+        action          Activity_0kyb9u9
+        element-label   "Activity_0kyb9u9"
+        case            default step-type "ExecutePrinter" action-type RUN
+        with-inputs     Flow_0iaelzn, DataStoreReference_1221tl9
+        produces-outputs    Event_0mxx05p suppress
         updates:
             Event_0mxx05p := Flow_0iaelzn
-        produces-outputs	DataObjectReference_15zyq6c
+        produces-outputs    DataObjectReference_15zyq6c
         updates:    DataObjectReference_15zyq6c := Result { verdict = Outcome::OK }
+    
+        element-labels ["Process_1", "Activity_1lazkw7"]
     }
     
     system Activity_14x2mh4
     {
         inputs
-        Report	DataStoreReference_0zb46u3
-        MeasureRequest	DataObjectReference_0hvxqpd
+        Report  DataStoreReference_0zb46u3
+        MeasureRequest  DataObjectReference_0hvxqpd
         
         outputs
-        Report		DataStoreReference_1r5xmmd
-        Result		DataObjectReference_01m0czw
-        Report		DataStoreReference_0zb46u3
+        Report      DataStoreReference_1r5xmmd
+        Result      DataObjectReference_01m0czw
+        Report      DataStoreReference_0zb46u3
     
         local
-        MeasureRequest	DataStoreReference_17wghfz
+        MeasureRequest  DataStoreReference_17wghfz
         
         
-        UNIT	Flow_07l0yyj
+        UNIT    Flow_07l0yyj
     
         // init
     
     
         desc "Activity_14x2mh4_Model"
         
-        action			Activity_1vhqu8s
-        case			default step-type "ExecuteInspection" action-type RUN
-        with-inputs		Flow_07l0yyj, DataStoreReference_17wghfz
-        produces-outputs	DataStoreReference_1r5xmmd symbolic-link
+        action          Activity_1vhqu8s
+        element-label   "Activity_1vhqu8s"
+        case            default step-type "ExecuteInspection" action-type RUN
+        with-inputs     Flow_07l0yyj, DataStoreReference_17wghfz
+        produces-outputs    DataStoreReference_1r5xmmd symbolic-link
         updates:    DataStoreReference_1r5xmmd := Report {
              id = DataStoreReference_17wghfz.id
             }
-        produces-outputs	DataObjectReference_01m0czw
+        produces-outputs    DataObjectReference_01m0czw
         updates:    DataObjectReference_01m0czw := Result { verdict = Outcome::OK }
         
-        action			Activity_08rviuu
-        case			default step-type "null" action-type COMPOSE
-        with-inputs		DataObjectReference_0hvxqpd, DataStoreReference_0zb46u3
-        with-guard		DataStoreReference_0zb46u3.id == DataObjectReference_0hvxqpd.id
-        produces-outputs	Flow_07l0yyj suppress
-        produces-outputs	DataStoreReference_17wghfz
+        action          Activity_08rviuu
+        element-label   "Activity_08rviuu"
+        case            default step-type "null" action-type COMPOSE
+        with-inputs     DataObjectReference_0hvxqpd, DataStoreReference_0zb46u3
+        with-guard      DataStoreReference_0zb46u3.id == DataObjectReference_0hvxqpd.id
+        produces-outputs    Flow_07l0yyj suppress
+        produces-outputs    DataStoreReference_17wghfz
         references {
             reportLinking: DataStoreReference_17wghfz.printJobReport := DataStoreReference_0zb46u3
         } symbolic-link
         updates:    DataStoreReference_17wghfz := DataObjectReference_0hvxqpd
-        produces-outputs	DataStoreReference_0zb46u3 symbolic-link suppress
+        produces-outputs    DataStoreReference_0zb46u3 symbolic-link suppress
         updates: DataStoreReference_0zb46u3 := DataStoreReference_0zb46u3
+    
+        element-labels ["Process_1", "Activity_14x2mh4"]
     }
     
     system Activity_1kfty5c
     {
         inputs
-        OptimizeRequest	DataObjectReference_0gm0nb7
-        Report	DataStoreReference_1r5xmmd
+        OptimizeRequest DataObjectReference_0gm0nb7
+        Report  DataStoreReference_1r5xmmd
         
         outputs
-        Result		DataObjectReference_0c253d3
-        CorrectionsReport		DataStoreReference_18mx7a8
-        Report		DataStoreReference_1r5xmmd
+        Result      DataObjectReference_0c253d3
+        CorrectionsReport       DataStoreReference_18mx7a8
+        Report      DataStoreReference_1r5xmmd
     
         local
-        OptimizeRequest	DataStoreReference_1h7cfk3
+        OptimizeRequest DataStoreReference_1h7cfk3
         
-        UNIT	Event_1oozdnw
-        UNIT	Flow_0y8u5pd
+        UNIT    Event_1oozdnw
+        UNIT    Flow_0y8u5pd
     
         // init
     
     
         desc "Activity_1kfty5c_Model"
         
-        action			Activity_1opg0oh
-        case			default step-type "null" action-type COMPOSE
-        with-inputs		DataObjectReference_0gm0nb7, DataStoreReference_1r5xmmd
-        with-guard		DataStoreReference_1r5xmmd.id == DataObjectReference_0gm0nb7.id
-        produces-outputs	Flow_0y8u5pd suppress
-        produces-outputs	DataStoreReference_1h7cfk3 symbolic-link
+        action          Activity_1opg0oh
+        element-label   "Activity_1opg0oh"
+        case            default step-type "null" action-type COMPOSE
+        with-inputs     DataObjectReference_0gm0nb7, DataStoreReference_1r5xmmd
+        with-guard      DataStoreReference_1r5xmmd.id == DataObjectReference_0gm0nb7.id
+        produces-outputs    Flow_0y8u5pd suppress
+        produces-outputs    DataStoreReference_1h7cfk3 symbolic-link
         updates:    DataStoreReference_1h7cfk3 := DataObjectReference_0gm0nb7
-        produces-outputs	DataStoreReference_1r5xmmd symbolic-link suppress
+        produces-outputs    DataStoreReference_1r5xmmd symbolic-link suppress
         updates: DataStoreReference_1r5xmmd := DataStoreReference_1r5xmmd
         
-        action			Activity_019bl5q
-        case			default step-type "ExecuteOptimizer" action-type RUN
-        with-inputs		Flow_0y8u5pd, DataStoreReference_1h7cfk3
-        produces-outputs	Event_1oozdnw suppress
+        action          Activity_019bl5q
+        element-label   "Activity_019bl5q"
+        case            default step-type "ExecuteOptimizer" action-type RUN
+        with-inputs     Flow_0y8u5pd, DataStoreReference_1h7cfk3
+        produces-outputs    Event_1oozdnw suppress
         updates:
             Event_1oozdnw := Flow_0y8u5pd
-        produces-outputs	DataStoreReference_18mx7a8 symbolic-link
+        produces-outputs    DataStoreReference_18mx7a8 symbolic-link
         updates:    DataStoreReference_18mx7a8 := CorrectionsReport {
              correctionsMap = 
                                 <map<int,CorrectionItem[]>>{
@@ -168,40 +180,42 @@ specification printer
             },
              id = DataStoreReference_1h7cfk3.id + 1
             }
-        produces-outputs	DataObjectReference_0c253d3
+        produces-outputs    DataObjectReference_0c253d3
+    
+        element-labels ["Process_1", "Activity_1kfty5c"]
     }
     
     system Activity_1v3jwys
     {
         inputs
-        Result	DataObjectReference_15zyq6c
-        Result	DataObjectReference_01m0czw
-        Result	DataObjectReference_0c253d3
-        PrintRequest	DataStoreReference_0wnjztj
-        Report	DataStoreReference_1r5xmmd
+        Result  DataObjectReference_15zyq6c
+        Result  DataObjectReference_01m0czw
+        Result  DataObjectReference_0c253d3
+        PrintRequest    DataStoreReference_0wnjztj
+        Report  DataStoreReference_1r5xmmd
         
         outputs
-        PrintRequest		DataObjectReference_0dobbvk
-        MeasureRequest		DataObjectReference_0hvxqpd
-        OptimizeRequest		DataObjectReference_0gm0nb7
-        Report		DataStoreReference_1r5xmmd
+        PrintRequest        DataObjectReference_0dobbvk
+        MeasureRequest      DataObjectReference_0hvxqpd
+        OptimizeRequest     DataObjectReference_0gm0nb7
+        Report      DataStoreReference_1r5xmmd
     
         local
-        FactoryCtx	Gateway_0p2uo9v
-        FactoryCtx	Gateway_1wpvmtk
+        FactoryCtx  Gateway_0p2uo9v
+        FactoryCtx  Gateway_1wpvmtk
         
         
-        FactoryCtx	Flow_16s4ey1
-        FactoryCtx	Flow_1dcdx0e
-        FactoryCtx	Flow_1dt29vl
-        FactoryCtx	Flow_0kbycuh
-        FactoryCtx	Flow_01m2s0h
-        FactoryCtx	Flow_09b0flo
-        FactoryCtx	Flow_1rkhqnd
-        FactoryCtx	Flow_1vq9t2p
-        FactoryCtx	Flow_0fe8hce
-        FactoryCtx	Flow_1y4bjf4
-        FactoryCtx	Flow_1f74bn4
+        FactoryCtx  Flow_16s4ey1
+        FactoryCtx  Flow_1dcdx0e
+        FactoryCtx  Flow_1dt29vl
+        FactoryCtx  Flow_0kbycuh
+        FactoryCtx  Flow_01m2s0h
+        FactoryCtx  Flow_09b0flo
+        FactoryCtx  Flow_1rkhqnd
+        FactoryCtx  Flow_1vq9t2p
+        FactoryCtx  Flow_0fe8hce
+        FactoryCtx  Flow_1y4bjf4
+        FactoryCtx  Flow_1f74bn4
     
         init
         Gateway_1wpvmtk := FactoryCtx {
@@ -237,17 +251,18 @@ specification printer
     
         desc "Activity_1v3jwys_Model"
         
-        action			Activity_04pcf0c
-        case			default
-        with-inputs		Gateway_1wpvmtk, DataStoreReference_0wnjztj
-        with-guard		DataStoreReference_0wnjztj.id == Gateway_1wpvmtk.id
-        produces-outputs	Flow_16s4ey1
+        action          Activity_04pcf0c
+        element-label   "Activity_04pcf0c"
+        case            default
+        with-inputs     Gateway_1wpvmtk, DataStoreReference_0wnjztj
+        with-guard      DataStoreReference_0wnjztj.id == Gateway_1wpvmtk.id
+        produces-outputs    Flow_16s4ey1
         updates:
             Flow_16s4ey1 := Gateway_1wpvmtk
             Flow_16s4ey1.color := DataStoreReference_0wnjztj.color
             Flow_16s4ey1.resolution := DataStoreReference_0wnjztj.resolution
             Flow_16s4ey1.scale := DataStoreReference_0wnjztj.scale
-        produces-outputs	DataObjectReference_0dobbvk
+        produces-outputs    DataObjectReference_0dobbvk
         updates:    DataObjectReference_0dobbvk := PrintRequest {
              id = DataStoreReference_0wnjztj.id,
              resolution = DataStoreReference_0wnjztj.resolution,
@@ -256,62 +271,69 @@ specification printer
              opType = DataStoreReference_0wnjztj.opType
             }
         
-        action			Activity_0ez4yi3
-        case			default
-        with-inputs		Gateway_0p2uo9v
-        produces-outputs	Gateway_1wpvmtk
+        action          Activity_0ez4yi3
+        element-label   "Activity_0ez4yi3"
+        case            default
+        with-inputs     Gateway_0p2uo9v
+        produces-outputs    Gateway_1wpvmtk
         updates:
             Gateway_1wpvmtk := Gateway_0p2uo9v
             Gateway_1wpvmtk.id := Gateway_1wpvmtk.id + 1
         
-        action			Activity_0ad3chm
-        case			default
-        with-inputs		Flow_01m2s0h, DataObjectReference_0c253d3
-        produces-outputs	Flow_09b0flo
+        action          Activity_0ad3chm
+        element-label   "Activity_0ad3chm"
+        case            default
+        with-inputs     Flow_01m2s0h, DataObjectReference_0c253d3
+        produces-outputs    Flow_09b0flo
         updates:
             Flow_09b0flo := Flow_01m2s0h
         
-        action			Gateway_1f8wap6
-        case			default
-        with-inputs		Flow_09b0flo, Flow_1vq9t2p
-        with-guard		Flow_1vq9t2p == Flow_09b0flo
-        produces-outputs	Gateway_0p2uo9v
+        action          Gateway_1f8wap6
+        element-label   "Gateway_1f8wap6"
+        case            default
+        with-inputs     Flow_09b0flo, Flow_1vq9t2p
+        with-guard      Flow_1vq9t2p == Flow_09b0flo
+        produces-outputs    Gateway_0p2uo9v
         updates:
             Gateway_0p2uo9v := Flow_09b0flo
         
-        action			Gateway_1j3rupx
-        case			default
-        with-inputs		Flow_1dcdx0e
-        produces-outputs	Flow_1y4bjf4
+        action          Gateway_1j3rupx
+        element-label   "Gateway_1j3rupx"
+        case            default
+        with-inputs     Flow_1dcdx0e
+        produces-outputs    Flow_1y4bjf4
         updates:
             Flow_1y4bjf4 := Flow_1dcdx0e
-        produces-outputs	Flow_1f74bn4
+        produces-outputs    Flow_1f74bn4
         updates:
             Flow_1f74bn4 := Flow_1dcdx0e
         
-        action			Activity_1uwysel
-        case			default
-        with-inputs		Flow_1dt29vl, DataObjectReference_01m0czw
-        produces-outputs	Flow_0kbycuh
+        action          Activity_1uwysel
+        element-label   "Activity_1uwysel"
+        case            default
+        with-inputs     Flow_1dt29vl, DataObjectReference_01m0czw
+        produces-outputs    Flow_0kbycuh
         updates:
             Flow_0kbycuh := Flow_1dt29vl
         
-        action			Activity_1c074wo
-        case			default
-        with-inputs		Flow_0fe8hce
-        produces-outputs	Flow_01m2s0h
+        action          Activity_1c074wo
+        element-label   "Activity_1c074wo"
+        case            default
+        with-inputs     Flow_0fe8hce
+        produces-outputs    Flow_01m2s0h
         updates:
             Flow_01m2s0h := Flow_0fe8hce
-        produces-outputs	DataObjectReference_0gm0nb7
+        produces-outputs    DataObjectReference_0gm0nb7
         updates:    DataObjectReference_0gm0nb7 := OptimizeRequest { id = Flow_0fe8hce.id }
         
-        action			Activity_1q0krpv
-        case			default
-        with-inputs		Flow_1f74bn4
-        produces-outputs	Flow_1rkhqnd
+        action          Activity_1q0krpv
+        element-label   "Activity_1q0krpv"
+        case            default
+        with-inputs     Flow_1f74bn4
+        produces-outputs    Flow_1rkhqnd
         updates:
             Flow_1rkhqnd := Flow_1f74bn4
-        produces-outputs	DataObjectReference_0dobbvk
+        produces-outputs    DataObjectReference_0dobbvk
         updates:    DataObjectReference_0dobbvk := PrintRequest {
              id = Flow_1f74bn4.id,
              resolution = Flow_1f74bn4.resolution,
@@ -320,47 +342,53 @@ specification printer
              opType = OperationType::PREP
             }
         
-        action			Activity_02lfj6a
-        case			default step-type "Assert_Visual_Inspection" action-type ASSERT
-        with-inputs		Flow_0kbycuh, DataStoreReference_1r5xmmd
+        action          Activity_02lfj6a
+        element-label   "Activity_02lfj6a"
+        case            default step-type "Assert_Visual_Inspection" action-type ASSERT
+        with-inputs     Flow_0kbycuh, DataStoreReference_1r5xmmd
         assertions default {
             assert_kpi: assert-that (DataStoreReference_1r5xmmd.kpi) {
               equal-to 9.0 within-margin relative (1.0)
             }
         }
-        produces-outputs	Flow_0fe8hce
+        produces-outputs    Flow_0fe8hce
         updates:
             Flow_0fe8hce := Flow_0kbycuh
-        produces-outputs	DataStoreReference_1r5xmmd symbolic-link
+        produces-outputs    DataStoreReference_1r5xmmd symbolic-link
         updates: DataStoreReference_1r5xmmd := DataStoreReference_1r5xmmd
         
-        action			Activity_18xgvcj
-        case			default
-        with-inputs		Flow_1y4bjf4
-        produces-outputs	Flow_1dt29vl
+        action          Activity_18xgvcj
+        element-label   "Activity_18xgvcj"
+        case            default
+        with-inputs     Flow_1y4bjf4
+        produces-outputs    Flow_1dt29vl
         updates:
             Flow_1dt29vl := Flow_1y4bjf4
-        produces-outputs	DataObjectReference_0hvxqpd
+        produces-outputs    DataObjectReference_0hvxqpd
         updates:    DataObjectReference_0hvxqpd := MeasureRequest {
              id = Flow_1y4bjf4.id
             }
         
-        action			Activity_05coj0b
-        case			default
-        with-inputs		Flow_1rkhqnd, DataObjectReference_15zyq6c
-        produces-outputs	Flow_1vq9t2p
+        action          Activity_05coj0b
+        element-label   "Activity_05coj0b"
+        case            default
+        with-inputs     Flow_1rkhqnd, DataObjectReference_15zyq6c
+        produces-outputs    Flow_1vq9t2p
         updates:
             Flow_1vq9t2p := Flow_1rkhqnd
         
-        action			Activity_1fczbkv
-        case			default
-        with-inputs		Flow_16s4ey1, DataObjectReference_15zyq6c
-        produces-outputs	Flow_1dcdx0e
+        action          Activity_1fczbkv
+        element-label   "Activity_1fczbkv"
+        case            default
+        with-inputs     Flow_16s4ey1, DataObjectReference_15zyq6c
+        produces-outputs    Flow_1dcdx0e
         updates:
             Flow_1dcdx0e := Flow_16s4ey1
+    
+        element-labels ["Process_1", "Activity_1v3jwys"]
     }
     
-	SUT-blocks Activity_1lazkw7 Activity_14x2mh4 Activity_1lazkw7 Activity_1kfty5c
-	depth-limits 300
-	num-tests 1
+    SUT-blocks Activity_1lazkw7 Activity_14x2mh4 Activity_1lazkw7 Activity_1kfty5c
+    depth-limits 300
+    num-tests 1
 }

--- a/bundles/nl.asml.matala.bpmn4s.tests/resources/expected/printer_sim/printer.ps
+++ b/bundles/nl.asml.matala.bpmn4s.tests/resources/expected/printer_sim/printer.ps
@@ -4,20 +4,20 @@ specification printer
     system Activity_1lazkw7
     {
         inputs
-        PrintRequest    DataObjectReference_0dobbvk
-        CorrectionsReport   DataStoreReference_18mx7a8
+        PrintRequest	DataObjectReference_0dobbvk
+        CorrectionsReport	DataStoreReference_18mx7a8
         
         outputs
-        Result      DataObjectReference_15zyq6c
-        Report      DataStoreReference_0zb46u3
+        Result		DataObjectReference_15zyq6c
+        Report		DataStoreReference_0zb46u3
     
         local
-        PrintRequest    DataStoreReference_1221tl9
+        PrintRequest	DataStoreReference_1221tl9
         
-        UNIT    Event_0mxx05p
-        UNIT    Event_0jcg6zx
-        UNIT    Flow_1u2qmtt
-        UNIT    Flow_0iaelzn
+        UNIT	Event_0mxx05p
+        UNIT	Event_0jcg6zx
+        UNIT	Flow_1u2qmtt
+        UNIT	Flow_0iaelzn
     
         init
         DataStoreReference_18mx7a8 := CorrectionsReport { 
@@ -37,46 +37,46 @@ specification printer
     
         desc "Activity_1lazkw7_Model"
         
-        action          Activity_13k0eiw
-        element-label   "Activity_13k0eiw"
-        case            default step-type "ExecutePrinter" action-type RUN
-        with-inputs     Flow_1u2qmtt, DataStoreReference_1221tl9
-        produces-outputs    Event_0jcg6zx suppress
+        action			Activity_13k0eiw
+        element-label	"Activity_13k0eiw"
+        case			default step-type "ExecutePrinter" action-type RUN
+        with-inputs		Flow_1u2qmtt, DataStoreReference_1221tl9
+        produces-outputs	Event_0jcg6zx suppress
         updates:
             Event_0jcg6zx := Flow_1u2qmtt
-        produces-outputs    DataObjectReference_15zyq6c
+        produces-outputs	DataObjectReference_15zyq6c
         updates:    DataObjectReference_15zyq6c := Result { verdict = Outcome::OK }
-        produces-outputs    DataStoreReference_0zb46u3 symbolic-link
+        produces-outputs	DataStoreReference_0zb46u3 symbolic-link
         updates:    DataStoreReference_0zb46u3 := Report {
              id = DataStoreReference_1221tl9.id
             }
         
-        action          Activity_0kjg94e
-        element-label   "Activity_0kjg94e"
-        case            default step-type "null" action-type COMPOSE
-        with-inputs     DataObjectReference_0dobbvk, DataStoreReference_18mx7a8
-        with-guard      DataStoreReference_18mx7a8.id == DataObjectReference_0dobbvk.id and DataObjectReference_0dobbvk.opType == OperationType::PRINT
-        produces-outputs    Flow_1u2qmtt suppress
-        produces-outputs    DataStoreReference_1221tl9 symbolic-link
+        action			Activity_0kjg94e
+        element-label	"Activity_0kjg94e"
+        case			default step-type "null" action-type COMPOSE
+        with-inputs		DataObjectReference_0dobbvk, DataStoreReference_18mx7a8
+        with-guard		DataStoreReference_18mx7a8.id == DataObjectReference_0dobbvk.id and DataObjectReference_0dobbvk.opType == OperationType::PRINT
+        produces-outputs	Flow_1u2qmtt suppress
+        produces-outputs	DataStoreReference_1221tl9 symbolic-link
         updates:    DataStoreReference_1221tl9 := DataObjectReference_0dobbvk
         
-        action          Activity_10lpfzr
-        element-label   "Activity_10lpfzr"
-        case            default step-type "null" action-type COMPOSE
-        with-inputs     DataObjectReference_0dobbvk
-        with-guard      DataObjectReference_0dobbvk.opType == OperationType::PREP
-        produces-outputs    Flow_0iaelzn suppress
-        produces-outputs    DataStoreReference_1221tl9 symbolic-link
+        action			Activity_10lpfzr
+        element-label	"Activity_10lpfzr"
+        case			default step-type "null" action-type COMPOSE
+        with-inputs		DataObjectReference_0dobbvk
+        with-guard		DataObjectReference_0dobbvk.opType == OperationType::PREP
+        produces-outputs	Flow_0iaelzn suppress
+        produces-outputs	DataStoreReference_1221tl9 symbolic-link
         updates:    DataStoreReference_1221tl9 := DataObjectReference_0dobbvk
         
-        action          Activity_0kyb9u9
-        element-label   "Activity_0kyb9u9"
-        case            default step-type "ExecutePrinter" action-type RUN
-        with-inputs     Flow_0iaelzn, DataStoreReference_1221tl9
-        produces-outputs    Event_0mxx05p suppress
+        action			Activity_0kyb9u9
+        element-label	"Activity_0kyb9u9"
+        case			default step-type "ExecutePrinter" action-type RUN
+        with-inputs		Flow_0iaelzn, DataStoreReference_1221tl9
+        produces-outputs	Event_0mxx05p suppress
         updates:
             Event_0mxx05p := Flow_0iaelzn
-        produces-outputs    DataObjectReference_15zyq6c
+        produces-outputs	DataObjectReference_15zyq6c
         updates:    DataObjectReference_15zyq6c := Result { verdict = Outcome::OK }
     
         element-labels ["Process_1", "Activity_1lazkw7"]
@@ -85,48 +85,48 @@ specification printer
     system Activity_14x2mh4
     {
         inputs
-        Report  DataStoreReference_0zb46u3
-        MeasureRequest  DataObjectReference_0hvxqpd
+        Report	DataStoreReference_0zb46u3
+        MeasureRequest	DataObjectReference_0hvxqpd
         
         outputs
-        Report      DataStoreReference_1r5xmmd
-        Result      DataObjectReference_01m0czw
-        Report      DataStoreReference_0zb46u3
+        Report		DataStoreReference_1r5xmmd
+        Result		DataObjectReference_01m0czw
+        Report		DataStoreReference_0zb46u3
     
         local
-        MeasureRequest  DataStoreReference_17wghfz
+        MeasureRequest	DataStoreReference_17wghfz
         
         
-        UNIT    Flow_07l0yyj
+        UNIT	Flow_07l0yyj
     
         // init
     
     
         desc "Activity_14x2mh4_Model"
         
-        action          Activity_1vhqu8s
-        element-label   "Activity_1vhqu8s"
-        case            default step-type "ExecuteInspection" action-type RUN
-        with-inputs     Flow_07l0yyj, DataStoreReference_17wghfz
-        produces-outputs    DataStoreReference_1r5xmmd symbolic-link
+        action			Activity_1vhqu8s
+        element-label	"Activity_1vhqu8s"
+        case			default step-type "ExecuteInspection" action-type RUN
+        with-inputs		Flow_07l0yyj, DataStoreReference_17wghfz
+        produces-outputs	DataStoreReference_1r5xmmd symbolic-link
         updates:    DataStoreReference_1r5xmmd := Report {
              id = DataStoreReference_17wghfz.id
             }
-        produces-outputs    DataObjectReference_01m0czw
+        produces-outputs	DataObjectReference_01m0czw
         updates:    DataObjectReference_01m0czw := Result { verdict = Outcome::OK }
         
-        action          Activity_08rviuu
-        element-label   "Activity_08rviuu"
-        case            default step-type "null" action-type COMPOSE
-        with-inputs     DataObjectReference_0hvxqpd, DataStoreReference_0zb46u3
-        with-guard      DataStoreReference_0zb46u3.id == DataObjectReference_0hvxqpd.id
-        produces-outputs    Flow_07l0yyj suppress
-        produces-outputs    DataStoreReference_17wghfz
+        action			Activity_08rviuu
+        element-label	"Activity_08rviuu"
+        case			default step-type "null" action-type COMPOSE
+        with-inputs		DataObjectReference_0hvxqpd, DataStoreReference_0zb46u3
+        with-guard		DataStoreReference_0zb46u3.id == DataObjectReference_0hvxqpd.id
+        produces-outputs	Flow_07l0yyj suppress
+        produces-outputs	DataStoreReference_17wghfz
         references {
             reportLinking: DataStoreReference_17wghfz.printJobReport := DataStoreReference_0zb46u3
         } symbolic-link
         updates:    DataStoreReference_17wghfz := DataObjectReference_0hvxqpd
-        produces-outputs    DataStoreReference_0zb46u3 symbolic-link suppress
+        produces-outputs	DataStoreReference_0zb46u3 symbolic-link suppress
         updates: DataStoreReference_0zb46u3 := DataStoreReference_0zb46u3
     
         element-labels ["Process_1", "Activity_14x2mh4"]
@@ -135,44 +135,44 @@ specification printer
     system Activity_1kfty5c
     {
         inputs
-        OptimizeRequest DataObjectReference_0gm0nb7
-        Report  DataStoreReference_1r5xmmd
+        OptimizeRequest	DataObjectReference_0gm0nb7
+        Report	DataStoreReference_1r5xmmd
         
         outputs
-        Result      DataObjectReference_0c253d3
-        CorrectionsReport       DataStoreReference_18mx7a8
-        Report      DataStoreReference_1r5xmmd
+        Result		DataObjectReference_0c253d3
+        CorrectionsReport		DataStoreReference_18mx7a8
+        Report		DataStoreReference_1r5xmmd
     
         local
-        OptimizeRequest DataStoreReference_1h7cfk3
+        OptimizeRequest	DataStoreReference_1h7cfk3
         
-        UNIT    Event_1oozdnw
-        UNIT    Flow_0y8u5pd
+        UNIT	Event_1oozdnw
+        UNIT	Flow_0y8u5pd
     
         // init
     
     
         desc "Activity_1kfty5c_Model"
         
-        action          Activity_1opg0oh
-        element-label   "Activity_1opg0oh"
-        case            default step-type "null" action-type COMPOSE
-        with-inputs     DataObjectReference_0gm0nb7, DataStoreReference_1r5xmmd
-        with-guard      DataStoreReference_1r5xmmd.id == DataObjectReference_0gm0nb7.id
-        produces-outputs    Flow_0y8u5pd suppress
-        produces-outputs    DataStoreReference_1h7cfk3 symbolic-link
+        action			Activity_1opg0oh
+        element-label	"Activity_1opg0oh"
+        case			default step-type "null" action-type COMPOSE
+        with-inputs		DataObjectReference_0gm0nb7, DataStoreReference_1r5xmmd
+        with-guard		DataStoreReference_1r5xmmd.id == DataObjectReference_0gm0nb7.id
+        produces-outputs	Flow_0y8u5pd suppress
+        produces-outputs	DataStoreReference_1h7cfk3 symbolic-link
         updates:    DataStoreReference_1h7cfk3 := DataObjectReference_0gm0nb7
-        produces-outputs    DataStoreReference_1r5xmmd symbolic-link suppress
+        produces-outputs	DataStoreReference_1r5xmmd symbolic-link suppress
         updates: DataStoreReference_1r5xmmd := DataStoreReference_1r5xmmd
         
-        action          Activity_019bl5q
-        element-label   "Activity_019bl5q"
-        case            default step-type "ExecuteOptimizer" action-type RUN
-        with-inputs     Flow_0y8u5pd, DataStoreReference_1h7cfk3
-        produces-outputs    Event_1oozdnw suppress
+        action			Activity_019bl5q
+        element-label	"Activity_019bl5q"
+        case			default step-type "ExecuteOptimizer" action-type RUN
+        with-inputs		Flow_0y8u5pd, DataStoreReference_1h7cfk3
+        produces-outputs	Event_1oozdnw suppress
         updates:
             Event_1oozdnw := Flow_0y8u5pd
-        produces-outputs    DataStoreReference_18mx7a8 symbolic-link
+        produces-outputs	DataStoreReference_18mx7a8 symbolic-link
         updates:    DataStoreReference_18mx7a8 := CorrectionsReport {
              correctionsMap = 
                                 <map<int,CorrectionItem[]>>{
@@ -180,7 +180,7 @@ specification printer
             },
              id = DataStoreReference_1h7cfk3.id + 1
             }
-        produces-outputs    DataObjectReference_0c253d3
+        produces-outputs	DataObjectReference_0c253d3
     
         element-labels ["Process_1", "Activity_1kfty5c"]
     }
@@ -188,34 +188,34 @@ specification printer
     system Activity_1v3jwys
     {
         inputs
-        Result  DataObjectReference_15zyq6c
-        Result  DataObjectReference_01m0czw
-        Result  DataObjectReference_0c253d3
-        PrintRequest    DataStoreReference_0wnjztj
-        Report  DataStoreReference_1r5xmmd
+        Result	DataObjectReference_15zyq6c
+        Result	DataObjectReference_01m0czw
+        Result	DataObjectReference_0c253d3
+        PrintRequest	DataStoreReference_0wnjztj
+        Report	DataStoreReference_1r5xmmd
         
         outputs
-        PrintRequest        DataObjectReference_0dobbvk
-        MeasureRequest      DataObjectReference_0hvxqpd
-        OptimizeRequest     DataObjectReference_0gm0nb7
-        Report      DataStoreReference_1r5xmmd
+        PrintRequest		DataObjectReference_0dobbvk
+        MeasureRequest		DataObjectReference_0hvxqpd
+        OptimizeRequest		DataObjectReference_0gm0nb7
+        Report		DataStoreReference_1r5xmmd
     
         local
-        FactoryCtx  Gateway_0p2uo9v
-        FactoryCtx  Gateway_1wpvmtk
+        FactoryCtx	Gateway_0p2uo9v
+        FactoryCtx	Gateway_1wpvmtk
         
         
-        FactoryCtx  Flow_16s4ey1
-        FactoryCtx  Flow_1dcdx0e
-        FactoryCtx  Flow_1dt29vl
-        FactoryCtx  Flow_0kbycuh
-        FactoryCtx  Flow_01m2s0h
-        FactoryCtx  Flow_09b0flo
-        FactoryCtx  Flow_1rkhqnd
-        FactoryCtx  Flow_1vq9t2p
-        FactoryCtx  Flow_0fe8hce
-        FactoryCtx  Flow_1y4bjf4
-        FactoryCtx  Flow_1f74bn4
+        FactoryCtx	Flow_16s4ey1
+        FactoryCtx	Flow_1dcdx0e
+        FactoryCtx	Flow_1dt29vl
+        FactoryCtx	Flow_0kbycuh
+        FactoryCtx	Flow_01m2s0h
+        FactoryCtx	Flow_09b0flo
+        FactoryCtx	Flow_1rkhqnd
+        FactoryCtx	Flow_1vq9t2p
+        FactoryCtx	Flow_0fe8hce
+        FactoryCtx	Flow_1y4bjf4
+        FactoryCtx	Flow_1f74bn4
     
         init
         Gateway_1wpvmtk := FactoryCtx {
@@ -251,18 +251,18 @@ specification printer
     
         desc "Activity_1v3jwys_Model"
         
-        action          Activity_04pcf0c
-        element-label   "Activity_04pcf0c"
-        case            default
-        with-inputs     Gateway_1wpvmtk, DataStoreReference_0wnjztj
-        with-guard      DataStoreReference_0wnjztj.id == Gateway_1wpvmtk.id
-        produces-outputs    Flow_16s4ey1
+        action			Activity_04pcf0c
+        element-label	"Activity_04pcf0c"
+        case			default
+        with-inputs		Gateway_1wpvmtk, DataStoreReference_0wnjztj
+        with-guard		DataStoreReference_0wnjztj.id == Gateway_1wpvmtk.id
+        produces-outputs	Flow_16s4ey1
         updates:
             Flow_16s4ey1 := Gateway_1wpvmtk
             Flow_16s4ey1.color := DataStoreReference_0wnjztj.color
             Flow_16s4ey1.resolution := DataStoreReference_0wnjztj.resolution
             Flow_16s4ey1.scale := DataStoreReference_0wnjztj.scale
-        produces-outputs    DataObjectReference_0dobbvk
+        produces-outputs	DataObjectReference_0dobbvk
         updates:    DataObjectReference_0dobbvk := PrintRequest {
              id = DataStoreReference_0wnjztj.id,
              resolution = DataStoreReference_0wnjztj.resolution,
@@ -271,69 +271,69 @@ specification printer
              opType = DataStoreReference_0wnjztj.opType
             }
         
-        action          Activity_0ez4yi3
-        element-label   "Activity_0ez4yi3"
-        case            default
-        with-inputs     Gateway_0p2uo9v
-        produces-outputs    Gateway_1wpvmtk
+        action			Activity_0ez4yi3
+        element-label	"Activity_0ez4yi3"
+        case			default
+        with-inputs		Gateway_0p2uo9v
+        produces-outputs	Gateway_1wpvmtk
         updates:
             Gateway_1wpvmtk := Gateway_0p2uo9v
             Gateway_1wpvmtk.id := Gateway_1wpvmtk.id + 1
         
-        action          Activity_0ad3chm
-        element-label   "Activity_0ad3chm"
-        case            default
-        with-inputs     Flow_01m2s0h, DataObjectReference_0c253d3
-        produces-outputs    Flow_09b0flo
+        action			Activity_0ad3chm
+        element-label	"Activity_0ad3chm"
+        case			default
+        with-inputs		Flow_01m2s0h, DataObjectReference_0c253d3
+        produces-outputs	Flow_09b0flo
         updates:
             Flow_09b0flo := Flow_01m2s0h
         
-        action          Gateway_1f8wap6
-        element-label   "Gateway_1f8wap6"
-        case            default
-        with-inputs     Flow_09b0flo, Flow_1vq9t2p
-        with-guard      Flow_1vq9t2p == Flow_09b0flo
-        produces-outputs    Gateway_0p2uo9v
+        action			Gateway_1f8wap6
+        element-label	"Gateway_1f8wap6"
+        case			default
+        with-inputs		Flow_09b0flo, Flow_1vq9t2p
+        with-guard		Flow_1vq9t2p == Flow_09b0flo
+        produces-outputs	Gateway_0p2uo9v
         updates:
             Gateway_0p2uo9v := Flow_09b0flo
         
-        action          Gateway_1j3rupx
-        element-label   "Gateway_1j3rupx"
-        case            default
-        with-inputs     Flow_1dcdx0e
-        produces-outputs    Flow_1y4bjf4
+        action			Gateway_1j3rupx
+        element-label	"Gateway_1j3rupx"
+        case			default
+        with-inputs		Flow_1dcdx0e
+        produces-outputs	Flow_1y4bjf4
         updates:
             Flow_1y4bjf4 := Flow_1dcdx0e
-        produces-outputs    Flow_1f74bn4
+        produces-outputs	Flow_1f74bn4
         updates:
             Flow_1f74bn4 := Flow_1dcdx0e
         
-        action          Activity_1uwysel
-        element-label   "Activity_1uwysel"
-        case            default
-        with-inputs     Flow_1dt29vl, DataObjectReference_01m0czw
-        produces-outputs    Flow_0kbycuh
+        action			Activity_1uwysel
+        element-label	"Activity_1uwysel"
+        case			default
+        with-inputs		Flow_1dt29vl, DataObjectReference_01m0czw
+        produces-outputs	Flow_0kbycuh
         updates:
             Flow_0kbycuh := Flow_1dt29vl
         
-        action          Activity_1c074wo
-        element-label   "Activity_1c074wo"
-        case            default
-        with-inputs     Flow_0fe8hce
-        produces-outputs    Flow_01m2s0h
+        action			Activity_1c074wo
+        element-label	"Activity_1c074wo"
+        case			default
+        with-inputs		Flow_0fe8hce
+        produces-outputs	Flow_01m2s0h
         updates:
             Flow_01m2s0h := Flow_0fe8hce
-        produces-outputs    DataObjectReference_0gm0nb7
+        produces-outputs	DataObjectReference_0gm0nb7
         updates:    DataObjectReference_0gm0nb7 := OptimizeRequest { id = Flow_0fe8hce.id }
         
-        action          Activity_1q0krpv
-        element-label   "Activity_1q0krpv"
-        case            default
-        with-inputs     Flow_1f74bn4
-        produces-outputs    Flow_1rkhqnd
+        action			Activity_1q0krpv
+        element-label	"Activity_1q0krpv"
+        case			default
+        with-inputs		Flow_1f74bn4
+        produces-outputs	Flow_1rkhqnd
         updates:
             Flow_1rkhqnd := Flow_1f74bn4
-        produces-outputs    DataObjectReference_0dobbvk
+        produces-outputs	DataObjectReference_0dobbvk
         updates:    DataObjectReference_0dobbvk := PrintRequest {
              id = Flow_1f74bn4.id,
              resolution = Flow_1f74bn4.resolution,
@@ -342,53 +342,53 @@ specification printer
              opType = OperationType::PREP
             }
         
-        action          Activity_02lfj6a
-        element-label   "Activity_02lfj6a"
-        case            default step-type "Assert_Visual_Inspection" action-type ASSERT
-        with-inputs     Flow_0kbycuh, DataStoreReference_1r5xmmd
+        action			Activity_02lfj6a
+        element-label	"Activity_02lfj6a"
+        case			default step-type "Assert_Visual_Inspection" action-type ASSERT
+        with-inputs		Flow_0kbycuh, DataStoreReference_1r5xmmd
         assertions default {
             assert_kpi: assert-that (DataStoreReference_1r5xmmd.kpi) {
               equal-to 9.0 within-margin relative (1.0)
             }
         }
-        produces-outputs    Flow_0fe8hce
+        produces-outputs	Flow_0fe8hce
         updates:
             Flow_0fe8hce := Flow_0kbycuh
-        produces-outputs    DataStoreReference_1r5xmmd symbolic-link
+        produces-outputs	DataStoreReference_1r5xmmd symbolic-link
         updates: DataStoreReference_1r5xmmd := DataStoreReference_1r5xmmd
         
-        action          Activity_18xgvcj
-        element-label   "Activity_18xgvcj"
-        case            default
-        with-inputs     Flow_1y4bjf4
-        produces-outputs    Flow_1dt29vl
+        action			Activity_18xgvcj
+        element-label	"Activity_18xgvcj"
+        case			default
+        with-inputs		Flow_1y4bjf4
+        produces-outputs	Flow_1dt29vl
         updates:
             Flow_1dt29vl := Flow_1y4bjf4
-        produces-outputs    DataObjectReference_0hvxqpd
+        produces-outputs	DataObjectReference_0hvxqpd
         updates:    DataObjectReference_0hvxqpd := MeasureRequest {
              id = Flow_1y4bjf4.id
             }
         
-        action          Activity_05coj0b
-        element-label   "Activity_05coj0b"
-        case            default
-        with-inputs     Flow_1rkhqnd, DataObjectReference_15zyq6c
-        produces-outputs    Flow_1vq9t2p
+        action			Activity_05coj0b
+        element-label	"Activity_05coj0b"
+        case			default
+        with-inputs		Flow_1rkhqnd, DataObjectReference_15zyq6c
+        produces-outputs	Flow_1vq9t2p
         updates:
             Flow_1vq9t2p := Flow_1rkhqnd
         
-        action          Activity_1fczbkv
-        element-label   "Activity_1fczbkv"
-        case            default
-        with-inputs     Flow_16s4ey1, DataObjectReference_15zyq6c
-        produces-outputs    Flow_1dcdx0e
+        action			Activity_1fczbkv
+        element-label	"Activity_1fczbkv"
+        case			default
+        with-inputs		Flow_16s4ey1, DataObjectReference_15zyq6c
+        produces-outputs	Flow_1dcdx0e
         updates:
             Flow_1dcdx0e := Flow_16s4ey1
     
         element-labels ["Process_1", "Activity_1v3jwys"]
     }
     
-    SUT-blocks Activity_1lazkw7 Activity_14x2mh4 Activity_1lazkw7 Activity_1kfty5c
-    depth-limits 300
-    num-tests 1
+	SUT-blocks Activity_1lazkw7 Activity_14x2mh4 Activity_1lazkw7 Activity_1kfty5c
+	depth-limits 300
+	num-tests 1
 }

--- a/bundles/nl.asml.matala.bpmn4s.tests/resources/expected/printer_tests/printer.ps
+++ b/bundles/nl.asml.matala.bpmn4s.tests/resources/expected/printer_tests/printer.ps
@@ -4,20 +4,20 @@ specification printer
     system PrintFactoryA3DPrinter
     {
         inputs
-        PrintRequest    printJob
-        CorrectionsReport   corrections
+        PrintRequest	printJob
+        CorrectionsReport	corrections
         
         outputs
-        Result      printResult
-        Report      printReport
+        Result		printResult
+        Report		printReport
     
         local
-        PrintRequest    request
+        PrintRequest	request
         
-        UNIT    Event_0mxx05p
-        UNIT    Event_0jcg6zx
-        UNIT    between_ComposePrintJob_and_RunPrintJob
-        UNIT    between_ComposePrepareJob_and_RunPrepareJob
+        UNIT	Event_0mxx05p
+        UNIT	Event_0jcg6zx
+        UNIT	between_ComposePrintJob_and_RunPrintJob
+        UNIT	between_ComposePrepareJob_and_RunPrepareJob
     
         init
         corrections := CorrectionsReport { 
@@ -37,46 +37,46 @@ specification printer
     
         desc "PrintFactoryA 3D Printer_Model"
         
-        action          RunPrintJob
-        element-label   "Run Print Job"
-        case            default step-type "ExecutePrinter" action-type RUN
-        with-inputs     between_ComposePrintJob_and_RunPrintJob, request
-        produces-outputs    Event_0jcg6zx suppress
+        action			RunPrintJob
+        element-label	"Run Print Job"
+        case			default step-type "ExecutePrinter" action-type RUN
+        with-inputs		between_ComposePrintJob_and_RunPrintJob, request
+        produces-outputs	Event_0jcg6zx suppress
         updates:
             Event_0jcg6zx := between_ComposePrintJob_and_RunPrintJob
-        produces-outputs    printResult
+        produces-outputs	printResult
         updates:    printResult := Result { verdict = Outcome::OK }
-        produces-outputs    printReport symbolic-link
+        produces-outputs	printReport symbolic-link
         updates:    printReport := Report {
              id = request.id
             }
         
-        action          ComposePrintJob
-        element-label   "Compose Print Job"
-        case            default step-type "null" action-type COMPOSE
-        with-inputs     printJob, corrections
-        with-guard      corrections.id == printJob.id and printJob.opType == OperationType::PRINT
-        produces-outputs    between_ComposePrintJob_and_RunPrintJob suppress
-        produces-outputs    request symbolic-link
+        action			ComposePrintJob
+        element-label	"Compose Print Job"
+        case			default step-type "null" action-type COMPOSE
+        with-inputs		printJob, corrections
+        with-guard		corrections.id == printJob.id and printJob.opType == OperationType::PRINT
+        produces-outputs	between_ComposePrintJob_and_RunPrintJob suppress
+        produces-outputs	request symbolic-link
         updates:    request := printJob
         
-        action          ComposePrepareJob
-        element-label   "Compose Prepare Job"
-        case            default step-type "null" action-type COMPOSE
-        with-inputs     printJob
-        with-guard      printJob.opType == OperationType::PREP
-        produces-outputs    between_ComposePrepareJob_and_RunPrepareJob suppress
-        produces-outputs    request symbolic-link
+        action			ComposePrepareJob
+        element-label	"Compose Prepare Job"
+        case			default step-type "null" action-type COMPOSE
+        with-inputs		printJob
+        with-guard		printJob.opType == OperationType::PREP
+        produces-outputs	between_ComposePrepareJob_and_RunPrepareJob suppress
+        produces-outputs	request symbolic-link
         updates:    request := printJob
         
-        action          RunPrepareJob
-        element-label   "Run Prepare Job"
-        case            default step-type "ExecutePrinter" action-type RUN
-        with-inputs     between_ComposePrepareJob_and_RunPrepareJob, request
-        produces-outputs    Event_0mxx05p suppress
+        action			RunPrepareJob
+        element-label	"Run Prepare Job"
+        case			default step-type "ExecutePrinter" action-type RUN
+        with-inputs		between_ComposePrepareJob_and_RunPrepareJob, request
+        produces-outputs	Event_0mxx05p suppress
         updates:
             Event_0mxx05p := between_ComposePrepareJob_and_RunPrepareJob
-        produces-outputs    printResult
+        produces-outputs	printResult
         updates:    printResult := Result { verdict = Outcome::OK }
     
         element-labels ["PrintFactory", "A 3D Printer"]
@@ -85,48 +85,48 @@ specification printer
     system PrintFactoryInspection
     {
         inputs
-        Report  printReport
-        MeasureRequest  inspectionJob
+        Report	printReport
+        MeasureRequest	inspectionJob
         
         outputs
-        Report      inspectionReport
-        Result      inspectionResult
-        Report      printReport
+        Report		inspectionReport
+        Result		inspectionResult
+        Report		printReport
     
         local
-        MeasureRequest  measureRequest
+        MeasureRequest	measureRequest
         
         
-        UNIT    between_ComposeVisualInspectionJob_and_RunVisualinspection
+        UNIT	between_ComposeVisualInspectionJob_and_RunVisualinspection
     
         // init
     
     
         desc "PrintFactoryInspection_Model"
         
-        action          RunVisualinspection
-        element-label   "Run Visual inspection"
-        case            default step-type "ExecuteInspection" action-type RUN
-        with-inputs     between_ComposeVisualInspectionJob_and_RunVisualinspection, measureRequest
-        produces-outputs    inspectionReport symbolic-link
+        action			RunVisualinspection
+        element-label	"Run Visual inspection"
+        case			default step-type "ExecuteInspection" action-type RUN
+        with-inputs		between_ComposeVisualInspectionJob_and_RunVisualinspection, measureRequest
+        produces-outputs	inspectionReport symbolic-link
         updates:    inspectionReport := Report {
              id = measureRequest.id
             }
-        produces-outputs    inspectionResult
+        produces-outputs	inspectionResult
         updates:    inspectionResult := Result { verdict = Outcome::OK }
         
-        action          ComposeVisualInspectionJob
-        element-label   "Compose Visual Inspection Job"
-        case            default step-type "null" action-type COMPOSE
-        with-inputs     inspectionJob, printReport
-        with-guard      printReport.id == inspectionJob.id
-        produces-outputs    between_ComposeVisualInspectionJob_and_RunVisualinspection suppress
-        produces-outputs    measureRequest
+        action			ComposeVisualInspectionJob
+        element-label	"Compose Visual Inspection Job"
+        case			default step-type "null" action-type COMPOSE
+        with-inputs		inspectionJob, printReport
+        with-guard		printReport.id == inspectionJob.id
+        produces-outputs	between_ComposeVisualInspectionJob_and_RunVisualinspection suppress
+        produces-outputs	measureRequest
         references {
             reportLinking: measureRequest.printJobReport := printReport
         } symbolic-link
         updates:    measureRequest := inspectionJob
-        produces-outputs    printReport symbolic-link suppress
+        produces-outputs	printReport symbolic-link suppress
         updates: printReport := printReport
     
         element-labels ["PrintFactory", "Inspection"]
@@ -135,44 +135,44 @@ specification printer
     system PrintFactoryOptimization
     {
         inputs
-        OptimizeRequest optJob
-        Report  inspectionReport
+        OptimizeRequest	optJob
+        Report	inspectionReport
         
         outputs
-        Result      optResult
-        CorrectionsReport       corrections
-        Report      inspectionReport
+        Result		optResult
+        CorrectionsReport		corrections
+        Report		inspectionReport
     
         local
-        OptimizeRequest optimizeJob
+        OptimizeRequest	optimizeJob
         
-        UNIT    Event_1oozdnw
-        UNIT    between_ComposeOptimizationJob_and_RunOptimizationJob
+        UNIT	Event_1oozdnw
+        UNIT	between_ComposeOptimizationJob_and_RunOptimizationJob
     
         // init
     
     
         desc "PrintFactoryOptimization_Model"
         
-        action          ComposeOptimizationJob
-        element-label   "Compose Optimization Job"
-        case            default step-type "null" action-type COMPOSE
-        with-inputs     optJob, inspectionReport
-        with-guard      inspectionReport.id == optJob.id
-        produces-outputs    between_ComposeOptimizationJob_and_RunOptimizationJob suppress
-        produces-outputs    optimizeJob symbolic-link
+        action			ComposeOptimizationJob
+        element-label	"Compose Optimization Job"
+        case			default step-type "null" action-type COMPOSE
+        with-inputs		optJob, inspectionReport
+        with-guard		inspectionReport.id == optJob.id
+        produces-outputs	between_ComposeOptimizationJob_and_RunOptimizationJob suppress
+        produces-outputs	optimizeJob symbolic-link
         updates:    optimizeJob := optJob
-        produces-outputs    inspectionReport symbolic-link suppress
+        produces-outputs	inspectionReport symbolic-link suppress
         updates: inspectionReport := inspectionReport
         
-        action          RunOptimizationJob
-        element-label   "Run Optimization Job"
-        case            default step-type "ExecuteOptimizer" action-type RUN
-        with-inputs     between_ComposeOptimizationJob_and_RunOptimizationJob, optimizeJob
-        produces-outputs    Event_1oozdnw suppress
+        action			RunOptimizationJob
+        element-label	"Run Optimization Job"
+        case			default step-type "ExecuteOptimizer" action-type RUN
+        with-inputs		between_ComposeOptimizationJob_and_RunOptimizationJob, optimizeJob
+        produces-outputs	Event_1oozdnw suppress
         updates:
             Event_1oozdnw := between_ComposeOptimizationJob_and_RunOptimizationJob
-        produces-outputs    corrections symbolic-link
+        produces-outputs	corrections symbolic-link
         updates:    corrections := CorrectionsReport {
              correctionsMap = 
                                 <map<int,CorrectionItem[]>>{
@@ -180,7 +180,7 @@ specification printer
             },
              id = optimizeJob.id + 1
             }
-        produces-outputs    optResult
+        produces-outputs	optResult
     
         element-labels ["PrintFactory", "Optimization"]
     }
@@ -188,34 +188,34 @@ specification printer
     system PrintFactoryFactoryAutomation
     {
         inputs
-        Result  printResult
-        Result  inspectionResult
-        Result  optResult
-        PrintRequest    printRequests
-        Report  inspectionReport
+        Result	printResult
+        Result	inspectionResult
+        Result	optResult
+        PrintRequest	printRequests
+        Report	inspectionReport
         
         outputs
-        PrintRequest        printJob
-        MeasureRequest      inspectionJob
-        OptimizeRequest     optJob
-        Report      inspectionReport
+        PrintRequest		printJob
+        MeasureRequest		inspectionJob
+        OptimizeRequest		optJob
+        Report		inspectionReport
     
         local
-        FactoryCtx  Gateway_0p2uo9v
-        FactoryCtx  Gateway_1wpvmtk
+        FactoryCtx	Gateway_0p2uo9v
+        FactoryCtx	Gateway_1wpvmtk
         
         
-        FactoryCtx  between_SendPrintJob_and_WaitforPrintJob
-        FactoryCtx  between_WaitforPrintJob_and_Gateway_1j3rupx
-        FactoryCtx  between_SendVisualInspectionJob_and_WaitforVisualInspection
-        FactoryCtx  between_WaitforVisualInspection_and_AssertVisualInspection
-        FactoryCtx  between_SendOptimizationJob_and_WaitforOptimizationJob
-        FactoryCtx  between_WaitforOptimizationJob_and_Gateway_1f8wap6
-        FactoryCtx  between_PreparePrinter_and_WaitforPrepare
-        FactoryCtx  between_WaitforPrepare_and_Gateway_1f8wap6
-        FactoryCtx  between_AssertVisualInspection_and_SendOptimizationJob
-        FactoryCtx  between_Gateway_1j3rupx_and_SendVisualInspectionJob
-        FactoryCtx  between_Gateway_1j3rupx_and_PreparePrinter
+        FactoryCtx	between_SendPrintJob_and_WaitforPrintJob
+        FactoryCtx	between_WaitforPrintJob_and_Gateway_1j3rupx
+        FactoryCtx	between_SendVisualInspectionJob_and_WaitforVisualInspection
+        FactoryCtx	between_WaitforVisualInspection_and_AssertVisualInspection
+        FactoryCtx	between_SendOptimizationJob_and_WaitforOptimizationJob
+        FactoryCtx	between_WaitforOptimizationJob_and_Gateway_1f8wap6
+        FactoryCtx	between_PreparePrinter_and_WaitforPrepare
+        FactoryCtx	between_WaitforPrepare_and_Gateway_1f8wap6
+        FactoryCtx	between_AssertVisualInspection_and_SendOptimizationJob
+        FactoryCtx	between_Gateway_1j3rupx_and_SendVisualInspectionJob
+        FactoryCtx	between_Gateway_1j3rupx_and_PreparePrinter
     
         init
         Gateway_1wpvmtk := FactoryCtx {
@@ -251,18 +251,18 @@ specification printer
     
         desc "PrintFactoryFactory Automation_Model"
         
-        action          SendPrintJob
-        element-label   "Send Print Job"
-        case            default
-        with-inputs     Gateway_1wpvmtk, printRequests
-        with-guard      printRequests.id == Gateway_1wpvmtk.id
-        produces-outputs    between_SendPrintJob_and_WaitforPrintJob
+        action			SendPrintJob
+        element-label	"Send Print Job"
+        case			default
+        with-inputs		Gateway_1wpvmtk, printRequests
+        with-guard		printRequests.id == Gateway_1wpvmtk.id
+        produces-outputs	between_SendPrintJob_and_WaitforPrintJob
         updates:
             between_SendPrintJob_and_WaitforPrintJob := Gateway_1wpvmtk
             between_SendPrintJob_and_WaitforPrintJob.color := printRequests.color
             between_SendPrintJob_and_WaitforPrintJob.resolution := printRequests.resolution
             between_SendPrintJob_and_WaitforPrintJob.scale := printRequests.scale
-        produces-outputs    printJob
+        produces-outputs	printJob
         updates:    printJob := PrintRequest {
              id = printRequests.id,
              resolution = printRequests.resolution,
@@ -271,69 +271,69 @@ specification printer
              opType = printRequests.opType
             }
         
-        action          NextJob
-        element-label   "Next Job"
-        case            default
-        with-inputs     Gateway_0p2uo9v
-        produces-outputs    Gateway_1wpvmtk
+        action			NextJob
+        element-label	"Next Job"
+        case			default
+        with-inputs		Gateway_0p2uo9v
+        produces-outputs	Gateway_1wpvmtk
         updates:
             Gateway_1wpvmtk := Gateway_0p2uo9v
             Gateway_1wpvmtk.id := Gateway_1wpvmtk.id + 1
         
-        action          WaitforOptimizationJob
-        element-label   "Wait for Optimization Job"
-        case            default
-        with-inputs     between_SendOptimizationJob_and_WaitforOptimizationJob, optResult
-        produces-outputs    between_WaitforOptimizationJob_and_Gateway_1f8wap6
+        action			WaitforOptimizationJob
+        element-label	"Wait for Optimization Job"
+        case			default
+        with-inputs		between_SendOptimizationJob_and_WaitforOptimizationJob, optResult
+        produces-outputs	between_WaitforOptimizationJob_and_Gateway_1f8wap6
         updates:
             between_WaitforOptimizationJob_and_Gateway_1f8wap6 := between_SendOptimizationJob_and_WaitforOptimizationJob
         
-        action          Gateway_1f8wap6
-        element-label   "Gateway_1f8wap6"
-        case            default
-        with-inputs     between_WaitforOptimizationJob_and_Gateway_1f8wap6, between_WaitforPrepare_and_Gateway_1f8wap6
-        with-guard      between_WaitforPrepare_and_Gateway_1f8wap6 == between_WaitforOptimizationJob_and_Gateway_1f8wap6
-        produces-outputs    Gateway_0p2uo9v
+        action			Gateway_1f8wap6
+        element-label	"Gateway_1f8wap6"
+        case			default
+        with-inputs		between_WaitforOptimizationJob_and_Gateway_1f8wap6, between_WaitforPrepare_and_Gateway_1f8wap6
+        with-guard		between_WaitforPrepare_and_Gateway_1f8wap6 == between_WaitforOptimizationJob_and_Gateway_1f8wap6
+        produces-outputs	Gateway_0p2uo9v
         updates:
             Gateway_0p2uo9v := between_WaitforOptimizationJob_and_Gateway_1f8wap6
         
-        action          Gateway_1j3rupx
-        element-label   "Gateway_1j3rupx"
-        case            default
-        with-inputs     between_WaitforPrintJob_and_Gateway_1j3rupx
-        produces-outputs    between_Gateway_1j3rupx_and_SendVisualInspectionJob
+        action			Gateway_1j3rupx
+        element-label	"Gateway_1j3rupx"
+        case			default
+        with-inputs		between_WaitforPrintJob_and_Gateway_1j3rupx
+        produces-outputs	between_Gateway_1j3rupx_and_SendVisualInspectionJob
         updates:
             between_Gateway_1j3rupx_and_SendVisualInspectionJob := between_WaitforPrintJob_and_Gateway_1j3rupx
-        produces-outputs    between_Gateway_1j3rupx_and_PreparePrinter
+        produces-outputs	between_Gateway_1j3rupx_and_PreparePrinter
         updates:
             between_Gateway_1j3rupx_and_PreparePrinter := between_WaitforPrintJob_and_Gateway_1j3rupx
         
-        action          WaitforVisualInspection
-        element-label   "Wait for Visual Inspection"
-        case            default
-        with-inputs     between_SendVisualInspectionJob_and_WaitforVisualInspection, inspectionResult
-        produces-outputs    between_WaitforVisualInspection_and_AssertVisualInspection
+        action			WaitforVisualInspection
+        element-label	"Wait for Visual Inspection"
+        case			default
+        with-inputs		between_SendVisualInspectionJob_and_WaitforVisualInspection, inspectionResult
+        produces-outputs	between_WaitforVisualInspection_and_AssertVisualInspection
         updates:
             between_WaitforVisualInspection_and_AssertVisualInspection := between_SendVisualInspectionJob_and_WaitforVisualInspection
         
-        action          SendOptimizationJob
-        element-label   "Send Optimization Job"
-        case            default
-        with-inputs     between_AssertVisualInspection_and_SendOptimizationJob
-        produces-outputs    between_SendOptimizationJob_and_WaitforOptimizationJob
+        action			SendOptimizationJob
+        element-label	"Send Optimization Job"
+        case			default
+        with-inputs		between_AssertVisualInspection_and_SendOptimizationJob
+        produces-outputs	between_SendOptimizationJob_and_WaitforOptimizationJob
         updates:
             between_SendOptimizationJob_and_WaitforOptimizationJob := between_AssertVisualInspection_and_SendOptimizationJob
-        produces-outputs    optJob
+        produces-outputs	optJob
         updates:    optJob := OptimizeRequest { id = between_AssertVisualInspection_and_SendOptimizationJob.id }
         
-        action          PreparePrinter
-        element-label   "Prepare Printer"
-        case            default
-        with-inputs     between_Gateway_1j3rupx_and_PreparePrinter
-        produces-outputs    between_PreparePrinter_and_WaitforPrepare
+        action			PreparePrinter
+        element-label	"Prepare Printer"
+        case			default
+        with-inputs		between_Gateway_1j3rupx_and_PreparePrinter
+        produces-outputs	between_PreparePrinter_and_WaitforPrepare
         updates:
             between_PreparePrinter_and_WaitforPrepare := between_Gateway_1j3rupx_and_PreparePrinter
-        produces-outputs    printJob
+        produces-outputs	printJob
         updates:    printJob := PrintRequest {
              id = between_Gateway_1j3rupx_and_PreparePrinter.id,
              resolution = between_Gateway_1j3rupx_and_PreparePrinter.resolution,
@@ -342,53 +342,53 @@ specification printer
              opType = OperationType::PREP
             }
         
-        action          AssertVisualInspection
-        element-label   "Assert Visual Inspection"
-        case            default step-type "Assert_Visual_Inspection" action-type ASSERT
-        with-inputs     between_WaitforVisualInspection_and_AssertVisualInspection, inspectionReport
+        action			AssertVisualInspection
+        element-label	"Assert Visual Inspection"
+        case			default step-type "Assert_Visual_Inspection" action-type ASSERT
+        with-inputs		between_WaitforVisualInspection_and_AssertVisualInspection, inspectionReport
         assertions default {
             assert_kpi: assert-that (inspectionReport.kpi) {
               equal-to 9.0 within-margin relative (1.0)
             }
         }
-        produces-outputs    between_AssertVisualInspection_and_SendOptimizationJob
+        produces-outputs	between_AssertVisualInspection_and_SendOptimizationJob
         updates:
             between_AssertVisualInspection_and_SendOptimizationJob := between_WaitforVisualInspection_and_AssertVisualInspection
-        produces-outputs    inspectionReport symbolic-link
+        produces-outputs	inspectionReport symbolic-link
         updates: inspectionReport := inspectionReport
         
-        action          SendVisualInspectionJob
-        element-label   "Send Visual Inspection Job"
-        case            default
-        with-inputs     between_Gateway_1j3rupx_and_SendVisualInspectionJob
-        produces-outputs    between_SendVisualInspectionJob_and_WaitforVisualInspection
+        action			SendVisualInspectionJob
+        element-label	"Send Visual Inspection Job"
+        case			default
+        with-inputs		between_Gateway_1j3rupx_and_SendVisualInspectionJob
+        produces-outputs	between_SendVisualInspectionJob_and_WaitforVisualInspection
         updates:
             between_SendVisualInspectionJob_and_WaitforVisualInspection := between_Gateway_1j3rupx_and_SendVisualInspectionJob
-        produces-outputs    inspectionJob
+        produces-outputs	inspectionJob
         updates:    inspectionJob := MeasureRequest {
              id = between_Gateway_1j3rupx_and_SendVisualInspectionJob.id
             }
         
-        action          WaitforPrepare
-        element-label   "Wait for Prepare"
-        case            default
-        with-inputs     between_PreparePrinter_and_WaitforPrepare, printResult
-        produces-outputs    between_WaitforPrepare_and_Gateway_1f8wap6
+        action			WaitforPrepare
+        element-label	"Wait for Prepare"
+        case			default
+        with-inputs		between_PreparePrinter_and_WaitforPrepare, printResult
+        produces-outputs	between_WaitforPrepare_and_Gateway_1f8wap6
         updates:
             between_WaitforPrepare_and_Gateway_1f8wap6 := between_PreparePrinter_and_WaitforPrepare
         
-        action          WaitforPrintJob
-        element-label   "Wait for Print Job"
-        case            default
-        with-inputs     between_SendPrintJob_and_WaitforPrintJob, printResult
-        produces-outputs    between_WaitforPrintJob_and_Gateway_1j3rupx
+        action			WaitforPrintJob
+        element-label	"Wait for Print Job"
+        case			default
+        with-inputs		between_SendPrintJob_and_WaitforPrintJob, printResult
+        produces-outputs	between_WaitforPrintJob_and_Gateway_1j3rupx
         updates:
             between_WaitforPrintJob_and_Gateway_1j3rupx := between_SendPrintJob_and_WaitforPrintJob
     
         element-labels ["PrintFactory", "Factory Automation"]
     }
     
-    SUT-blocks PrintFactoryA3DPrinter PrintFactoryInspection PrintFactoryA3DPrinter PrintFactoryOptimization
-    depth-limits 300
-    num-tests 1
+	SUT-blocks PrintFactoryA3DPrinter PrintFactoryInspection PrintFactoryA3DPrinter PrintFactoryOptimization
+	depth-limits 300
+	num-tests 1
 }

--- a/bundles/nl.asml.matala.bpmn4s.tests/resources/expected/printer_tests/printer.ps
+++ b/bundles/nl.asml.matala.bpmn4s.tests/resources/expected/printer_tests/printer.ps
@@ -4,20 +4,20 @@ specification printer
     system PrintFactoryA3DPrinter
     {
         inputs
-        PrintRequest	printJob
-        CorrectionsReport	corrections
+        PrintRequest    printJob
+        CorrectionsReport   corrections
         
         outputs
-        Result		printResult
-        Report		printReport
+        Result      printResult
+        Report      printReport
     
         local
-        PrintRequest	request
+        PrintRequest    request
         
-        UNIT	Event_0mxx05p
-        UNIT	Event_0jcg6zx
-        UNIT	between_ComposePrintJob_and_RunPrintJob
-        UNIT	between_ComposePrepareJob_and_RunPrepareJob
+        UNIT    Event_0mxx05p
+        UNIT    Event_0jcg6zx
+        UNIT    between_ComposePrintJob_and_RunPrintJob
+        UNIT    between_ComposePrepareJob_and_RunPrepareJob
     
         init
         corrections := CorrectionsReport { 
@@ -37,130 +37,142 @@ specification printer
     
         desc "PrintFactoryA 3D Printer_Model"
         
-        action			RunPrintJob
-        case			default step-type "ExecutePrinter" action-type RUN
-        with-inputs		between_ComposePrintJob_and_RunPrintJob, request
-        produces-outputs	Event_0jcg6zx suppress
+        action          RunPrintJob
+        element-label   "Run Print Job"
+        case            default step-type "ExecutePrinter" action-type RUN
+        with-inputs     between_ComposePrintJob_and_RunPrintJob, request
+        produces-outputs    Event_0jcg6zx suppress
         updates:
             Event_0jcg6zx := between_ComposePrintJob_and_RunPrintJob
-        produces-outputs	printResult
+        produces-outputs    printResult
         updates:    printResult := Result { verdict = Outcome::OK }
-        produces-outputs	printReport symbolic-link
+        produces-outputs    printReport symbolic-link
         updates:    printReport := Report {
              id = request.id
             }
         
-        action			ComposePrintJob
-        case			default step-type "null" action-type COMPOSE
-        with-inputs		printJob, corrections
-        with-guard		corrections.id == printJob.id and printJob.opType == OperationType::PRINT
-        produces-outputs	between_ComposePrintJob_and_RunPrintJob suppress
-        produces-outputs	request symbolic-link
+        action          ComposePrintJob
+        element-label   "Compose Print Job"
+        case            default step-type "null" action-type COMPOSE
+        with-inputs     printJob, corrections
+        with-guard      corrections.id == printJob.id and printJob.opType == OperationType::PRINT
+        produces-outputs    between_ComposePrintJob_and_RunPrintJob suppress
+        produces-outputs    request symbolic-link
         updates:    request := printJob
         
-        action			ComposePrepareJob
-        case			default step-type "null" action-type COMPOSE
-        with-inputs		printJob
-        with-guard		printJob.opType == OperationType::PREP
-        produces-outputs	between_ComposePrepareJob_and_RunPrepareJob suppress
-        produces-outputs	request symbolic-link
+        action          ComposePrepareJob
+        element-label   "Compose Prepare Job"
+        case            default step-type "null" action-type COMPOSE
+        with-inputs     printJob
+        with-guard      printJob.opType == OperationType::PREP
+        produces-outputs    between_ComposePrepareJob_and_RunPrepareJob suppress
+        produces-outputs    request symbolic-link
         updates:    request := printJob
         
-        action			RunPrepareJob
-        case			default step-type "ExecutePrinter" action-type RUN
-        with-inputs		between_ComposePrepareJob_and_RunPrepareJob, request
-        produces-outputs	Event_0mxx05p suppress
+        action          RunPrepareJob
+        element-label   "Run Prepare Job"
+        case            default step-type "ExecutePrinter" action-type RUN
+        with-inputs     between_ComposePrepareJob_and_RunPrepareJob, request
+        produces-outputs    Event_0mxx05p suppress
         updates:
             Event_0mxx05p := between_ComposePrepareJob_and_RunPrepareJob
-        produces-outputs	printResult
+        produces-outputs    printResult
         updates:    printResult := Result { verdict = Outcome::OK }
+    
+        element-labels ["PrintFactory", "A 3D Printer"]
     }
     
     system PrintFactoryInspection
     {
         inputs
-        Report	printReport
-        MeasureRequest	inspectionJob
+        Report  printReport
+        MeasureRequest  inspectionJob
         
         outputs
-        Report		inspectionReport
-        Result		inspectionResult
-        Report		printReport
+        Report      inspectionReport
+        Result      inspectionResult
+        Report      printReport
     
         local
-        MeasureRequest	measureRequest
+        MeasureRequest  measureRequest
         
         
-        UNIT	between_ComposeVisualInspectionJob_and_RunVisualinspection
+        UNIT    between_ComposeVisualInspectionJob_and_RunVisualinspection
     
         // init
     
     
         desc "PrintFactoryInspection_Model"
         
-        action			RunVisualinspection
-        case			default step-type "ExecuteInspection" action-type RUN
-        with-inputs		between_ComposeVisualInspectionJob_and_RunVisualinspection, measureRequest
-        produces-outputs	inspectionReport symbolic-link
+        action          RunVisualinspection
+        element-label   "Run Visual inspection"
+        case            default step-type "ExecuteInspection" action-type RUN
+        with-inputs     between_ComposeVisualInspectionJob_and_RunVisualinspection, measureRequest
+        produces-outputs    inspectionReport symbolic-link
         updates:    inspectionReport := Report {
              id = measureRequest.id
             }
-        produces-outputs	inspectionResult
+        produces-outputs    inspectionResult
         updates:    inspectionResult := Result { verdict = Outcome::OK }
         
-        action			ComposeVisualInspectionJob
-        case			default step-type "null" action-type COMPOSE
-        with-inputs		inspectionJob, printReport
-        with-guard		printReport.id == inspectionJob.id
-        produces-outputs	between_ComposeVisualInspectionJob_and_RunVisualinspection suppress
-        produces-outputs	measureRequest
+        action          ComposeVisualInspectionJob
+        element-label   "Compose Visual Inspection Job"
+        case            default step-type "null" action-type COMPOSE
+        with-inputs     inspectionJob, printReport
+        with-guard      printReport.id == inspectionJob.id
+        produces-outputs    between_ComposeVisualInspectionJob_and_RunVisualinspection suppress
+        produces-outputs    measureRequest
         references {
             reportLinking: measureRequest.printJobReport := printReport
         } symbolic-link
         updates:    measureRequest := inspectionJob
-        produces-outputs	printReport symbolic-link suppress
+        produces-outputs    printReport symbolic-link suppress
         updates: printReport := printReport
+    
+        element-labels ["PrintFactory", "Inspection"]
     }
     
     system PrintFactoryOptimization
     {
         inputs
-        OptimizeRequest	optJob
-        Report	inspectionReport
+        OptimizeRequest optJob
+        Report  inspectionReport
         
         outputs
-        Result		optResult
-        CorrectionsReport		corrections
-        Report		inspectionReport
+        Result      optResult
+        CorrectionsReport       corrections
+        Report      inspectionReport
     
         local
-        OptimizeRequest	optimizeJob
+        OptimizeRequest optimizeJob
         
-        UNIT	Event_1oozdnw
-        UNIT	between_ComposeOptimizationJob_and_RunOptimizationJob
+        UNIT    Event_1oozdnw
+        UNIT    between_ComposeOptimizationJob_and_RunOptimizationJob
     
         // init
     
     
         desc "PrintFactoryOptimization_Model"
         
-        action			ComposeOptimizationJob
-        case			default step-type "null" action-type COMPOSE
-        with-inputs		optJob, inspectionReport
-        with-guard		inspectionReport.id == optJob.id
-        produces-outputs	between_ComposeOptimizationJob_and_RunOptimizationJob suppress
-        produces-outputs	optimizeJob symbolic-link
+        action          ComposeOptimizationJob
+        element-label   "Compose Optimization Job"
+        case            default step-type "null" action-type COMPOSE
+        with-inputs     optJob, inspectionReport
+        with-guard      inspectionReport.id == optJob.id
+        produces-outputs    between_ComposeOptimizationJob_and_RunOptimizationJob suppress
+        produces-outputs    optimizeJob symbolic-link
         updates:    optimizeJob := optJob
-        produces-outputs	inspectionReport symbolic-link suppress
+        produces-outputs    inspectionReport symbolic-link suppress
         updates: inspectionReport := inspectionReport
         
-        action			RunOptimizationJob
-        case			default step-type "ExecuteOptimizer" action-type RUN
-        with-inputs		between_ComposeOptimizationJob_and_RunOptimizationJob, optimizeJob
-        produces-outputs	Event_1oozdnw suppress
+        action          RunOptimizationJob
+        element-label   "Run Optimization Job"
+        case            default step-type "ExecuteOptimizer" action-type RUN
+        with-inputs     between_ComposeOptimizationJob_and_RunOptimizationJob, optimizeJob
+        produces-outputs    Event_1oozdnw suppress
         updates:
             Event_1oozdnw := between_ComposeOptimizationJob_and_RunOptimizationJob
-        produces-outputs	corrections symbolic-link
+        produces-outputs    corrections symbolic-link
         updates:    corrections := CorrectionsReport {
              correctionsMap = 
                                 <map<int,CorrectionItem[]>>{
@@ -168,40 +180,42 @@ specification printer
             },
              id = optimizeJob.id + 1
             }
-        produces-outputs	optResult
+        produces-outputs    optResult
+    
+        element-labels ["PrintFactory", "Optimization"]
     }
     
     system PrintFactoryFactoryAutomation
     {
         inputs
-        Result	printResult
-        Result	inspectionResult
-        Result	optResult
-        PrintRequest	printRequests
-        Report	inspectionReport
+        Result  printResult
+        Result  inspectionResult
+        Result  optResult
+        PrintRequest    printRequests
+        Report  inspectionReport
         
         outputs
-        PrintRequest		printJob
-        MeasureRequest		inspectionJob
-        OptimizeRequest		optJob
-        Report		inspectionReport
+        PrintRequest        printJob
+        MeasureRequest      inspectionJob
+        OptimizeRequest     optJob
+        Report      inspectionReport
     
         local
-        FactoryCtx	Gateway_0p2uo9v
-        FactoryCtx	Gateway_1wpvmtk
+        FactoryCtx  Gateway_0p2uo9v
+        FactoryCtx  Gateway_1wpvmtk
         
         
-        FactoryCtx	between_SendPrintJob_and_WaitforPrintJob
-        FactoryCtx	between_WaitforPrintJob_and_Gateway_1j3rupx
-        FactoryCtx	between_SendVisualInspectionJob_and_WaitforVisualInspection
-        FactoryCtx	between_WaitforVisualInspection_and_AssertVisualInspection
-        FactoryCtx	between_SendOptimizationJob_and_WaitforOptimizationJob
-        FactoryCtx	between_WaitforOptimizationJob_and_Gateway_1f8wap6
-        FactoryCtx	between_PreparePrinter_and_WaitforPrepare
-        FactoryCtx	between_WaitforPrepare_and_Gateway_1f8wap6
-        FactoryCtx	between_AssertVisualInspection_and_SendOptimizationJob
-        FactoryCtx	between_Gateway_1j3rupx_and_SendVisualInspectionJob
-        FactoryCtx	between_Gateway_1j3rupx_and_PreparePrinter
+        FactoryCtx  between_SendPrintJob_and_WaitforPrintJob
+        FactoryCtx  between_WaitforPrintJob_and_Gateway_1j3rupx
+        FactoryCtx  between_SendVisualInspectionJob_and_WaitforVisualInspection
+        FactoryCtx  between_WaitforVisualInspection_and_AssertVisualInspection
+        FactoryCtx  between_SendOptimizationJob_and_WaitforOptimizationJob
+        FactoryCtx  between_WaitforOptimizationJob_and_Gateway_1f8wap6
+        FactoryCtx  between_PreparePrinter_and_WaitforPrepare
+        FactoryCtx  between_WaitforPrepare_and_Gateway_1f8wap6
+        FactoryCtx  between_AssertVisualInspection_and_SendOptimizationJob
+        FactoryCtx  between_Gateway_1j3rupx_and_SendVisualInspectionJob
+        FactoryCtx  between_Gateway_1j3rupx_and_PreparePrinter
     
         init
         Gateway_1wpvmtk := FactoryCtx {
@@ -237,17 +251,18 @@ specification printer
     
         desc "PrintFactoryFactory Automation_Model"
         
-        action			SendPrintJob
-        case			default
-        with-inputs		Gateway_1wpvmtk, printRequests
-        with-guard		printRequests.id == Gateway_1wpvmtk.id
-        produces-outputs	between_SendPrintJob_and_WaitforPrintJob
+        action          SendPrintJob
+        element-label   "Send Print Job"
+        case            default
+        with-inputs     Gateway_1wpvmtk, printRequests
+        with-guard      printRequests.id == Gateway_1wpvmtk.id
+        produces-outputs    between_SendPrintJob_and_WaitforPrintJob
         updates:
             between_SendPrintJob_and_WaitforPrintJob := Gateway_1wpvmtk
             between_SendPrintJob_and_WaitforPrintJob.color := printRequests.color
             between_SendPrintJob_and_WaitforPrintJob.resolution := printRequests.resolution
             between_SendPrintJob_and_WaitforPrintJob.scale := printRequests.scale
-        produces-outputs	printJob
+        produces-outputs    printJob
         updates:    printJob := PrintRequest {
              id = printRequests.id,
              resolution = printRequests.resolution,
@@ -256,62 +271,69 @@ specification printer
              opType = printRequests.opType
             }
         
-        action			NextJob
-        case			default
-        with-inputs		Gateway_0p2uo9v
-        produces-outputs	Gateway_1wpvmtk
+        action          NextJob
+        element-label   "Next Job"
+        case            default
+        with-inputs     Gateway_0p2uo9v
+        produces-outputs    Gateway_1wpvmtk
         updates:
             Gateway_1wpvmtk := Gateway_0p2uo9v
             Gateway_1wpvmtk.id := Gateway_1wpvmtk.id + 1
         
-        action			WaitforOptimizationJob
-        case			default
-        with-inputs		between_SendOptimizationJob_and_WaitforOptimizationJob, optResult
-        produces-outputs	between_WaitforOptimizationJob_and_Gateway_1f8wap6
+        action          WaitforOptimizationJob
+        element-label   "Wait for Optimization Job"
+        case            default
+        with-inputs     between_SendOptimizationJob_and_WaitforOptimizationJob, optResult
+        produces-outputs    between_WaitforOptimizationJob_and_Gateway_1f8wap6
         updates:
             between_WaitforOptimizationJob_and_Gateway_1f8wap6 := between_SendOptimizationJob_and_WaitforOptimizationJob
         
-        action			Gateway_1f8wap6
-        case			default
-        with-inputs		between_WaitforOptimizationJob_and_Gateway_1f8wap6, between_WaitforPrepare_and_Gateway_1f8wap6
-        with-guard		between_WaitforPrepare_and_Gateway_1f8wap6 == between_WaitforOptimizationJob_and_Gateway_1f8wap6
-        produces-outputs	Gateway_0p2uo9v
+        action          Gateway_1f8wap6
+        element-label   "Gateway_1f8wap6"
+        case            default
+        with-inputs     between_WaitforOptimizationJob_and_Gateway_1f8wap6, between_WaitforPrepare_and_Gateway_1f8wap6
+        with-guard      between_WaitforPrepare_and_Gateway_1f8wap6 == between_WaitforOptimizationJob_and_Gateway_1f8wap6
+        produces-outputs    Gateway_0p2uo9v
         updates:
             Gateway_0p2uo9v := between_WaitforOptimizationJob_and_Gateway_1f8wap6
         
-        action			Gateway_1j3rupx
-        case			default
-        with-inputs		between_WaitforPrintJob_and_Gateway_1j3rupx
-        produces-outputs	between_Gateway_1j3rupx_and_SendVisualInspectionJob
+        action          Gateway_1j3rupx
+        element-label   "Gateway_1j3rupx"
+        case            default
+        with-inputs     between_WaitforPrintJob_and_Gateway_1j3rupx
+        produces-outputs    between_Gateway_1j3rupx_and_SendVisualInspectionJob
         updates:
             between_Gateway_1j3rupx_and_SendVisualInspectionJob := between_WaitforPrintJob_and_Gateway_1j3rupx
-        produces-outputs	between_Gateway_1j3rupx_and_PreparePrinter
+        produces-outputs    between_Gateway_1j3rupx_and_PreparePrinter
         updates:
             between_Gateway_1j3rupx_and_PreparePrinter := between_WaitforPrintJob_and_Gateway_1j3rupx
         
-        action			WaitforVisualInspection
-        case			default
-        with-inputs		between_SendVisualInspectionJob_and_WaitforVisualInspection, inspectionResult
-        produces-outputs	between_WaitforVisualInspection_and_AssertVisualInspection
+        action          WaitforVisualInspection
+        element-label   "Wait for Visual Inspection"
+        case            default
+        with-inputs     between_SendVisualInspectionJob_and_WaitforVisualInspection, inspectionResult
+        produces-outputs    between_WaitforVisualInspection_and_AssertVisualInspection
         updates:
             between_WaitforVisualInspection_and_AssertVisualInspection := between_SendVisualInspectionJob_and_WaitforVisualInspection
         
-        action			SendOptimizationJob
-        case			default
-        with-inputs		between_AssertVisualInspection_and_SendOptimizationJob
-        produces-outputs	between_SendOptimizationJob_and_WaitforOptimizationJob
+        action          SendOptimizationJob
+        element-label   "Send Optimization Job"
+        case            default
+        with-inputs     between_AssertVisualInspection_and_SendOptimizationJob
+        produces-outputs    between_SendOptimizationJob_and_WaitforOptimizationJob
         updates:
             between_SendOptimizationJob_and_WaitforOptimizationJob := between_AssertVisualInspection_and_SendOptimizationJob
-        produces-outputs	optJob
+        produces-outputs    optJob
         updates:    optJob := OptimizeRequest { id = between_AssertVisualInspection_and_SendOptimizationJob.id }
         
-        action			PreparePrinter
-        case			default
-        with-inputs		between_Gateway_1j3rupx_and_PreparePrinter
-        produces-outputs	between_PreparePrinter_and_WaitforPrepare
+        action          PreparePrinter
+        element-label   "Prepare Printer"
+        case            default
+        with-inputs     between_Gateway_1j3rupx_and_PreparePrinter
+        produces-outputs    between_PreparePrinter_and_WaitforPrepare
         updates:
             between_PreparePrinter_and_WaitforPrepare := between_Gateway_1j3rupx_and_PreparePrinter
-        produces-outputs	printJob
+        produces-outputs    printJob
         updates:    printJob := PrintRequest {
              id = between_Gateway_1j3rupx_and_PreparePrinter.id,
              resolution = between_Gateway_1j3rupx_and_PreparePrinter.resolution,
@@ -320,47 +342,53 @@ specification printer
              opType = OperationType::PREP
             }
         
-        action			AssertVisualInspection
-        case			default step-type "Assert_Visual_Inspection" action-type ASSERT
-        with-inputs		between_WaitforVisualInspection_and_AssertVisualInspection, inspectionReport
+        action          AssertVisualInspection
+        element-label   "Assert Visual Inspection"
+        case            default step-type "Assert_Visual_Inspection" action-type ASSERT
+        with-inputs     between_WaitforVisualInspection_and_AssertVisualInspection, inspectionReport
         assertions default {
             assert_kpi: assert-that (inspectionReport.kpi) {
               equal-to 9.0 within-margin relative (1.0)
             }
         }
-        produces-outputs	between_AssertVisualInspection_and_SendOptimizationJob
+        produces-outputs    between_AssertVisualInspection_and_SendOptimizationJob
         updates:
             between_AssertVisualInspection_and_SendOptimizationJob := between_WaitforVisualInspection_and_AssertVisualInspection
-        produces-outputs	inspectionReport symbolic-link
+        produces-outputs    inspectionReport symbolic-link
         updates: inspectionReport := inspectionReport
         
-        action			SendVisualInspectionJob
-        case			default
-        with-inputs		between_Gateway_1j3rupx_and_SendVisualInspectionJob
-        produces-outputs	between_SendVisualInspectionJob_and_WaitforVisualInspection
+        action          SendVisualInspectionJob
+        element-label   "Send Visual Inspection Job"
+        case            default
+        with-inputs     between_Gateway_1j3rupx_and_SendVisualInspectionJob
+        produces-outputs    between_SendVisualInspectionJob_and_WaitforVisualInspection
         updates:
             between_SendVisualInspectionJob_and_WaitforVisualInspection := between_Gateway_1j3rupx_and_SendVisualInspectionJob
-        produces-outputs	inspectionJob
+        produces-outputs    inspectionJob
         updates:    inspectionJob := MeasureRequest {
              id = between_Gateway_1j3rupx_and_SendVisualInspectionJob.id
             }
         
-        action			WaitforPrepare
-        case			default
-        with-inputs		between_PreparePrinter_and_WaitforPrepare, printResult
-        produces-outputs	between_WaitforPrepare_and_Gateway_1f8wap6
+        action          WaitforPrepare
+        element-label   "Wait for Prepare"
+        case            default
+        with-inputs     between_PreparePrinter_and_WaitforPrepare, printResult
+        produces-outputs    between_WaitforPrepare_and_Gateway_1f8wap6
         updates:
             between_WaitforPrepare_and_Gateway_1f8wap6 := between_PreparePrinter_and_WaitforPrepare
         
-        action			WaitforPrintJob
-        case			default
-        with-inputs		between_SendPrintJob_and_WaitforPrintJob, printResult
-        produces-outputs	between_WaitforPrintJob_and_Gateway_1j3rupx
+        action          WaitforPrintJob
+        element-label   "Wait for Print Job"
+        case            default
+        with-inputs     between_SendPrintJob_and_WaitforPrintJob, printResult
+        produces-outputs    between_WaitforPrintJob_and_Gateway_1j3rupx
         updates:
             between_WaitforPrintJob_and_Gateway_1j3rupx := between_SendPrintJob_and_WaitforPrintJob
+    
+        element-labels ["PrintFactory", "Factory Automation"]
     }
     
-	SUT-blocks PrintFactoryA3DPrinter PrintFactoryInspection PrintFactoryA3DPrinter PrintFactoryOptimization
-	depth-limits 300
-	num-tests 1
+    SUT-blocks PrintFactoryA3DPrinter PrintFactoryInspection PrintFactoryA3DPrinter PrintFactoryOptimization
+    depth-limits 300
+    num-tests 1
 }

--- a/bundles/nl.asml.matala.bpmn4s/src/nl/asml/matala/bpmn4s/bpmn4s/Bpmn4sCompiler.java
+++ b/bundles/nl.asml.matala.bpmn4s/src/nl/asml/matala/bpmn4s/bpmn4s/Bpmn4sCompiler.java
@@ -20,6 +20,7 @@ import java.nio.file.Paths;
 import java.util.AbstractMap;
 import java.util.AbstractSet;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -208,6 +209,7 @@ public class Bpmn4sCompiler{
 				if (hasChildComponents(c)){ continue; } // skip top level components
 				String component = "";
 				String cname = compile(c.getId());
+				String qname = fabSpecQualifiedLabels(c);
 				component += "system " + sanitize(cname) + "\r\n{\r\n";
 				String inOut = fabSpecInputOutput(c);
 				String local = fabSpecLocal(c);
@@ -224,6 +226,7 @@ public class Bpmn4sCompiler{
 				component += indent(sutConfs);
 				component += "\n";
 				component += indent(desc);
+				component += "\n"+indent(qname)+"\n";
 				component += "}\n\n";
 				result.append(indent(component));	
 			}
@@ -270,6 +273,17 @@ public class Bpmn4sCompiler{
 		if (c.getDataInputs().isEmpty()) { inStr = "//" + inStr; }
 		if (c.getDataOutputs().isEmpty()) { outStr = "//" + outStr; }
 		return inStr + "\n" + outStr;
+	}
+	
+	/**
+	 * For a system in the pspec, fetch the list of labels for nested elements for its element-labels section.
+	 * @param c is the component that corresponds one to one with a pspec system.
+	 * @return a List of String with the nested elements labels.
+	 */
+	private String fabSpecQualifiedLabels(Element c) {
+		List<String> qnames = compileNestedComponentLabels(c.getId());
+		String items = qnames.stream().map(s -> '"' + s + '"' ).collect(Collectors.joining(", "));
+		return "element-labels " + "[" + items +"]";
 	}
 
 	/**
@@ -507,6 +521,7 @@ public class Bpmn4sCompiler{
 					// Name of context as defined by user at front end:
 					String compCtxName = model.getElementById(cId).getContextName();
 					task += "action\t\t\t" + sanitize(repr(node)) + "\n";
+					task += "element-label\t"  + '"' + repr(node) + '"' + "\n";
 					// STEP TYPE
 					String stepConf = "";
 					if (model.isComposeTask(node.getId())) {
@@ -966,6 +981,26 @@ public class Bpmn4sCompiler{
 			return getCompiledComponentName(elId);
 		}
 		return repr(model.getElementById(elId));
+	}
+
+	/**
+	 * Compile list with names of nested Elements <el>.
+	 */
+	protected List<String> compileNestedComponentLabels(String elId) {
+		if (model.isComponent(elId)) {
+			return getNestedComponentLabels(elId);
+		}
+		return Arrays.asList(repr(model.getElementById(elId)));
+	}
+	
+	protected List<String> getNestedComponentLabels(String componentId) {
+		Element component = model.getElementById(componentId);
+		/* Nested components are compiled with their fully qualified name. */
+		List<String> qname_list = component.getParentComponents().stream()
+				.map(e -> repr(model.getElementById(e)))
+				.collect(Collectors.toList());
+		qname_list.add(repr(component));
+		return qname_list;
 	}
 	
 	/**

--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/Product.xtext
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/Product.xtext
@@ -73,9 +73,9 @@ Block:
             ('suts' sutvars += [expr::Variable|ID] (',' sutvars+=[expr::Variable|ID])*)? &
 			('init' initActions+=AssignmentAction*)? &
 			'desc' type = STRING
-			('element-labels' '[' elabels += STRING (',' elabels+=STRING+)* ']')?
 		)
 		functions += Function*
+		('element-labels' '[' elabels += STRING (',' elabels+=STRING+)* ']')?
 	'}'
 ;
 

--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/Product.xtext
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/Product.xtext
@@ -73,6 +73,7 @@ Block:
             ('suts' sutvars += [expr::Variable|ID] (',' sutvars+=[expr::Variable|ID])*)? &
 			('init' initActions+=AssignmentAction*)? &
 			'desc' type = STRING
+			('element-labels' '[' elabels += STRING (',' elabels+=STRING+)* ']')?
 		)
 		functions += Function*
 	'}'
@@ -80,6 +81,7 @@ Block:
 
 Function:
 	'action' name = ID
+	('element-label'  elabels = STRING )?
 	updates += Update*
 ;
 

--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/generator/PetriNet.xtend
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/generator/PetriNet.xtend
@@ -337,6 +337,7 @@ class PetriNet {
 				 String topology_name, 
 				 List<String> listOfEnvBlocks,
 				 List<String> listOfAssertTransitions,
+				 Map<String, String> mapOfTransitionQnames,
 				 Map<String, ? extends Set<String>> mapOfSuppressTransitionVars,
 				 List<String> inout_places, 
 				 List<String> init_places, 
@@ -385,6 +386,7 @@ class PetriNet {
 		    listOfEnvBlocks = []
 		    listOfSUTActions = []
 		    mapOfSuppressTransitionVars = {}
+		    mapOfTransitionQnames = {}
 		    map_of_transition_modes = {}
 		    map_transition_modes_to_name = {}
 		    constraint_dict = {}
@@ -397,6 +399,7 @@ class PetriNet {
 		        self.listOfEnvBlocks = [«FOR elm : listOfEnvBlocks SEPARATOR ','»"«elm»"«ENDFOR»]
 		        self.listOfSUTActions = [«FOR elm : listOfAssertTransitions SEPARATOR ','»"«elm»"«ENDFOR»]
 		        self.mapOfSuppressTransitionVars = {«FOR k : mapOfSuppressTransitionVars.keySet SEPARATOR ','»'«k»': [«FOR v : mapOfSuppressTransitionVars.get(k) SEPARATOR ','»'«v»'«ENDFOR»]«ENDFOR»}
+		        self.mapOfTransitionQnames = {«FOR k : mapOfTransitionQnames.keySet SEPARATOR ','»'«k»': '«mapOfTransitionQnames.get(k)»'«ENDFOR»}
 		        self.n = PetriNet('«topology_name»')
 		        self.n.globals["Data"] = Data
 		        self.n.globals.declare("import json")
@@ -494,7 +497,7 @@ class PetriNet {
 		                    j = j + 1
 		                _test_scn.compute_dependencies()
 		                _test_scn.generate_viz(i, output_dir=p.plantuml_dir)
-		                _test_scn.generateTSpec(i, pn.sutTypesList, pn.sutVarTransitionMap, output_dir=p.tspec_dir)
+		                _test_scn.generateTSpec(i, pn.sutTypesList, pn.sutVarTransitionMap, pn.mapOfTransitionQnames, output_dir=p.tspec_dir)
 		                _tests.list_of_test_scn.append(_test_scn)
 		            i = i + 1
 		            

--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/generator/ProductGenerator.xtend
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/generator/ProductGenerator.xtend
@@ -17,6 +17,7 @@ package nl.asml.matala.product.generator
 
 import java.util.ArrayList
 import java.util.HashMap
+import java.util.LinkedHashMap
 import java.util.List
 import java.util.Map
 import java.util.Set
@@ -107,6 +108,7 @@ class ProductGenerator extends AbstractGenerator {
 			for(b : prod.specification.envBlock) listOfEnvBlocks.add(b.name)
 			
 			var listOfAssertTransitions = new ArrayList<String>
+			var mapOfTransitionQnames = new LinkedHashMap<String,String>
 			for(b : prod.specification.blocks) {
 				if (b.block !== null) {
 					val block = b.block
@@ -119,6 +121,7 @@ class ProductGenerator extends AbstractGenerator {
 						        || u.actionType.equals(ActionType.ASSERT)
 						    ) {
 						        listOfAssertTransitions.add(transitionName)
+						        mapOfTransitionQnames.put(transitionName, new Utils().printConstraint(u))
 						    }
 						    
 						    // Added DB. 15.04.2025. Create map of sut-var to transitions
@@ -174,10 +177,10 @@ class ProductGenerator extends AbstractGenerator {
 			}
 			
 			fsa.generateFile('CPNServer//' + specName + '//' + specName + '.py', pnet.toSnakes(
-			    specName, specName, listOfEnvBlocks, listOfAssertTransitions, 
-			    mapOfSuppressTransitionVars, inout_places, 
-			    init_places, depth_limit, num_tests, sutTransitionMap
-			))
+                specName, specName, listOfEnvBlocks, listOfAssertTransitions,
+                 mapOfTransitionQnames, mapOfSuppressTransitionVars, inout_places,
+                init_places, depth_limit, num_tests, sutTransitionMap
+            ))
 			//fsa.generateFile('CPNServer//' + specName + '//' + 'server.py', (new FlaskSimulationGenerator).generateServer(name))
 			//fsa.generateFile('CPNserver.py', (new FlaskSimulationGenerator).generateCPNServer)	
 			//fsa.generateFile('CPNclient.py', (new FlaskSimulationGenerator).generateCPNClient(specName))
@@ -240,7 +243,8 @@ class ProductGenerator extends AbstractGenerator {
 			{
 				System.out.println("  > case: " + update.name)
 				var tname = f.name + "_" + update.name + "@" + update.stepType + "@" + update.actionType + "@"
-				var tr = new Transition(block.name, block.name+"_"+tname)
+				var qname = new Utils().printConstraint(update)
+				var tr = new Transition(block.name, block.name+"_"+tname, qname)
 				pnet.transitions.add(tr)
 				var input_var_list = new HashMap<String,TypeDecl> // ArrayList<String>
 				for(v : update.fnInp) 

--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/generator/Transition.xtend
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/generator/Transition.xtend
@@ -16,8 +16,10 @@ package nl.asml.matala.product.generator
 class Transition {
 	public var bname = new String
 	public var name = new String
-	new (String b, String n) {
+	public var qname = new String
+	new (String b, String n, String q) {
 		bname = b
 		name = n
+		qname = q
 	}
 }

--- a/bundles/nl.asml.matala.product/src/nl/asml/matala/product/generator/Utils.xtend
+++ b/bundles/nl.asml.matala.product/src/nl/asml/matala/product/generator/Utils.xtend
@@ -436,7 +436,7 @@ class Utils
                     #     txt += self.recurseJson(j[jk], "%s.%s" % (k,jk))
                 return txt
                 
-            def generateTSpec(self, idx, sutTypesList, sutVarTransitionMap, output_dir):
+            def generateTSpec(self, idx, sutTypesList, sutVarTransitionMap, transitionQnameMap, output_dir):
                 txt = ""
                 txt += "import \"«pSpecFile»\"\n\n"
                 «(new Utils()).usageList(prod)»
@@ -463,6 +463,9 @@ class Utils
                             if not "null" in parts[1]:
                                 type_name = " assert-type: \"%s\"" % parts[1] 
                             txt += "\nassert-step-name: %s%s\n" % (new_name, type_name)
+                        if parts[0] in transitionQnameMap:
+                            qname = transitionQnameMap[parts[0]]
+                            txt += "action-case: %s\n" % (qname)
                         for elm in self.step_dependencies:
                             if elm.step_name == name:
                                 parts = elm.depends_on.split("@")

--- a/bundles/nl.esi.comma.abstracttestspecification/src/nl/esi/comma/abstracttestspecification/AbstractTestspecification.xtext
+++ b/bundles/nl.esi.comma.abstracttestspecification/src/nl/esi/comma/abstracttestspecification/AbstractTestspecification.xtext
@@ -72,6 +72,7 @@ ExecutableStep:
 
 ComposeStep:
     'compose-step-name' ':' name = ID
+    ('action-case' ':' caseRef = [prod::Update|QualifiedName] ) ?
     stepRef += StepReference*
     'input-binding' ':' input += Binding+
     'output-data' ':' output += Binding+ (suppress=Suppress)? // do not generate these in concrete TSpec
@@ -82,6 +83,7 @@ ComposeStep:
 RunStep:
     'run-step-name' ':' name = ID
     ('step-type' ':' stepType += STRING)?
+    ('action-case' ':' caseRef = [prod::Update|QualifiedName] ) ?
     stepRef += StepReference*
     'input-binding' ':' input += Binding+
     'output-data' ':' output += Binding+ (suppress=Suppress)? // do not generate these in concrete TSpec
@@ -91,6 +93,7 @@ RunStep:
 AssertionStep:
     'assert-step-name' ':' name = ID
     ('assert-type' ':' stepType += STRING)?
+    ('action-case' ':' caseRef = [prod::Update|QualifiedName] ) ?
     stepRef += StepReference*
     'input-binding' ':' input += Binding+
     'output-data' ':' output += Binding+ (suppress=Suppress)? // do not generate these in concrete TSpec


### PR DESCRIPTION
As we reach a point where generating graphical artifacts from our test cases becomes necessary (for analysis purposes), I noticed we lacked means to retrieve labels written in the BPMN models at the abstract tspec stage of our toolchain. Such content is needed to make bpmn models which are readable by the user. To enable the retrieval of these labels, I added support for:

- [x] linking from run/assert/compose steps (in ```.atspec``` files) back to the ```case``` statements in actions at the ```.ps``` files (as a qualified name)
- [x] cascading BPMN element labels into ```action``` sections of in ```.ps``` files (as a unique string)
- [x] cascading BPMN nested component labels into ```system``` sections of in ```.ps``` files (as a list of strings)
- [x] generation of the aforementioned fields using data from the ```PetriNet``` Python code
- [x] regression testing verifying the expected output files with needed updates   