### PR TITLE
shortening timestamp and filenames of resulting fast artifacts

### DIFF
--- a/bundles/nl.esi.comma.project.standard.cli/dist/simulator/CPNServer.py
+++ b/bundles/nl.esi.comma.project.standard.cli/dist/simulator/CPNServer.py
@@ -126,13 +126,13 @@ def handle_bpmn():
     fname = _bpmn.filename
     filename = fname
     bpmn_path = os.path.join(TEMP_PATH,f"{filename}.bpmn")
-    
+    _bpmn.save(bpmn_path)
+
     status_code = 200
     response = {'response': {'uuid': filename}}
     try:
         if utils.is_loaded_module(filename): 
             raise Exception(F"BPMN model '{filename}' is already loaded!")
-        _bpmn.save(bpmn_path)
         module, result = build_and_load_model(bpmn_path)
         bpmn_dir = os.path.join(module.__path__[0],'bpmn')
         os.makedirs(bpmn_dir, exist_ok=True)

--- a/bundles/nl.esi.comma.project.standard.cli/dist/simulator/CPNServer.py
+++ b/bundles/nl.esi.comma.project.standard.cli/dist/simulator/CPNServer.py
@@ -124,7 +124,7 @@ def generate_fast_tests( model_path:str, num_tests:int=1, depth_limit:int=500):
 def handle_bpmn():
     _bpmn = request.files['bpmn-file']
     fname = _bpmn.filename
-    filename = f'{fname}{utils.gensym(prefix="_",timestamp=True)}'
+    filename = fname
     bpmn_path = os.path.join(TEMP_PATH,f"{filename}.bpmn")
     
     status_code = 200
@@ -169,7 +169,7 @@ def test_generator():
     depthLimit = _args.get('depth-limit',1000)
 
     fname = _bpmn.filename
-    filename = f'{fname}{utils.gensym(prefix="_",timestamp=True)}'
+    filename = fname
     model_path = os.path.join(TEMP_PATH,f"{filename}.bpmn")
     _bpmn.save(model_path)
 

--- a/bundles/nl.esi.comma.project.standard.cli/dist/simulator/CPNUtils.py
+++ b/bundles/nl.esi.comma.project.standard.cli/dist/simulator/CPNUtils.py
@@ -92,7 +92,7 @@ def gensym(length=32, prefix="gensym_", timestamp:bool=False):
     """
     if timestamp:
         now = datetime.datetime.now()
-        symbol = now.strftime("%Y%m%d_%H%M%S%f")
+        symbol = now.strftime("%m%d_%H%M%S")
         return prefix + symbol    
     alphabet = string.ascii_uppercase + string.ascii_lowercase + string.digits
     symbol = "".join([secrets.choice(alphabet) for i in range(length)])

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/to/fast/FromConcreteToFast.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/to/fast/FromConcreteToFast.xtend
@@ -48,6 +48,7 @@ import static extension nl.esi.comma.types.utilities.FileSystemAccessUtil.*
 import java.util.Set
 import java.util.LinkedHashSet
 import nl.esi.comma.expressions.expression.ExpressionRecord
+import nl.esi.comma.testspecification.testspecification.AssertionStep
 
 class FromConcreteToFast extends AbstractGenerator {
 
@@ -86,6 +87,7 @@ class FromConcreteToFast extends AbstractGenerator {
         // 1) using the .tspec file
         val modelInst = res.contents.head as TSMain
         val model = modelInst.model as TestDefinition
+        shortenStepNames(model)
 
         // 2) create mapping data-implementation to filenames (in .params files)
         var tsi = new TestSpecificationInstance
@@ -155,6 +157,24 @@ class FromConcreteToFast extends AbstractGenerator {
         for (ss : test_single_sequence.stepSeqRef) {
             for (step : ss.step.filter(RunStep))
                 listStepSequence.add(step)
+        }
+        return listStepSequence
+    }
+
+    def private shortenStepNames(TestDefinition td) {
+        var pat = Pattern.compile("_[^_]+_+default_[0-9]+")
+        var listStepSequence = new ArrayList<RunStep>
+        var test_single_sequence = td.testSeq.head
+        for (ss : test_single_sequence.stepSeqRef) {
+            for (step : ss.step){
+                var mat = pat.matcher(step.inputVar.name); mat.find
+                var prefix =  switch(step) {
+                    RunStep: 'step'
+                    AssertionStep: 'assertion'
+                    default: throw new UnsupportedOperationException("Unsupported type")
+                }
+                step.inputVar.name = prefix + mat.group
+            }
         }
         return listStepSequence
     }

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/to/fast/FromConcreteToFast.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/to/fast/FromConcreteToFast.xtend
@@ -162,7 +162,7 @@ class FromConcreteToFast extends AbstractGenerator {
     }
 
     def private shortenStepNames(TestDefinition td) {
-        var pat = Pattern.compile("_[^_]+_+default_[0-9]+")
+        var pat = Pattern.compile("_[^_]+_+default_[0-9]+$")
         var listStepSequence = new ArrayList<RunStep>
         var test_single_sequence = td.testSeq.head
         for (ss : test_single_sequence.stepSeqRef) {

--- a/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/to/fast/RefKVPGenerator.xtend
+++ b/bundles/nl.esi.comma.testspecification/src/nl/esi/comma/testspecification/generator/to/fast/RefKVPGenerator.xtend
@@ -191,11 +191,7 @@ class RefKVPGenerator {
     }
 
     def getDatacheckId(String label, AssertionStep assertStep) {
-        return String.format(
-            "%s__@__%s",
-            label,
-            assertStep.inputVar.name
-        )
+        return assertStep.inputVar.name
     }
 
     def List<String> expression(Expression expr, List<String> prefix) {


### PR DESCRIPTION
To shorten the filenames and reduce issues with windows long path limitations:
- [x] Steps and assertion identifiers have been shortened 
- [x] FAST artifacts are named using a unique suffixes `_«run step name»_default_«numeric id»`
- [x] BPMN files are saved by the server with a shorter timestamp. 
