### PR TITLE
Restoring timestamp suffix on bpmn filenames received via API

### DIFF
--- a/bundles/nl.esi.comma.project.standard.cli/dist/simulator/CPNServer.py
+++ b/bundles/nl.esi.comma.project.standard.cli/dist/simulator/CPNServer.py
@@ -124,7 +124,7 @@ def generate_fast_tests( model_path:str, num_tests:int=1, depth_limit:int=500):
 def handle_bpmn():
     _bpmn = request.files['bpmn-file']
     fname = _bpmn.filename
-    filename = fname
+    filename = fname + utils.gensym(prefix="_",timestamp=True)
     bpmn_path = os.path.join(TEMP_PATH,f"{filename}.bpmn")
     _bpmn.save(bpmn_path)
 
@@ -169,7 +169,7 @@ def test_generator():
     depthLimit = _args.get('depth-limit',1000)
 
     fname = _bpmn.filename
-    filename = fname
+    filename = fname + utils.gensym(prefix="_",timestamp=True)
     model_path = os.path.join(TEMP_PATH,f"{filename}.bpmn")
     _bpmn.save(model_path)
 


### PR DESCRIPTION
To avoid unsuccessful unloading of (snake-lib) classes, a timestamp has been added to the bpmn filename (and hence class name).